### PR TITLE
feat(infra-bootstrap-crds): add subsystem - infra-bootstrap-crds

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  ".": "0.0.0"
+  "infrastructure/bootstrap/crds": "0.0.0"
 }

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -37,7 +37,8 @@ module.exports = {
         'dev-tools',
         'github-actions',
         'renovate',
-        'release'
+        'release',
+        'infra-bootstrap-crds'
       ]
     ],
 

--- a/infrastructure/bootstrap/crds/cert-manager/kustomization.yaml
+++ b/infrastructure/bootstrap/crds/cert-manager/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+# renovate-gh-release-asset: datasource=github-releases depName=cert-manager/cert-manager
+- https://github.com/cert-manager/cert-manager/releases/download/v1.15.3/cert-manager.crds.yaml
+
+###########################################################
+# allow these CRDs to be adopted by Flux HelmRelease
+###########################################################
+patches:
+# yamllint disable-line rule:indentation
+- patch: |-
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        meta.helm.sh/release-name: cert-manager
+        meta.helm.sh/release-namespace: cert-manager
+      labels:
+        app.kubernetes.io/managed-by: Helm
+        helm.toolkit.fluxcd.io/name: cert-manager-release
+        helm.toolkit.fluxcd.io/namespace: flux-system
+      name: irrelevant
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition

--- a/infrastructure/bootstrap/crds/cloudnative-pg/kustomization.yaml
+++ b/infrastructure/bootstrap/crds/cloudnative-pg/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+# renovate-gh-release-asset: datasource=github-releases depName=cloudnative-pg/cloudnative-pg
+- https://github.com/cloudnative-pg/cloudnative-pg/releases/download/v1.24.0/cnpg-1.24.0.yaml
+
+patches:
+###########################################################
+# allow these CRDs to be adopted by Flux HelmRelease
+###########################################################
+# yamllint disable-line rule:indentation
+- patch: |-
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        meta.helm.sh/release-name: cloudnative-pg
+        meta.helm.sh/release-namespace: cnpg-system
+      labels:
+        app.kubernetes.io/managed-by: Helm
+        helm.toolkit.fluxcd.io/name: cloudnative-pg-release
+        helm.toolkit.fluxcd.io/namespace: flux-system
+      name: irrelevant
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition

--- a/infrastructure/bootstrap/crds/external-secrets/kustomization.yaml
+++ b/infrastructure/bootstrap/crds/external-secrets/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+# renovate-gh-raw-url: datasource=github-releases depName=external-secrets/external-secrets
+- https://raw.githubusercontent.com/external-secrets/external-secrets/v0.10.3/deploy/crds/bundle.yaml
+
+patches:
+###########################################################
+# allow these CRDs to be adopted by Flux HelmRelease
+###########################################################
+# yamllint disable-line rule:indentation
+- patch: |-
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        meta.helm.sh/release-name: external-secrets
+        meta.helm.sh/release-namespace: external-secrets
+      labels:
+        app.kubernetes.io/managed-by: Helm
+        helm.toolkit.fluxcd.io/name: external-secrets-release
+        helm.toolkit.fluxcd.io/namespace: flux-system
+      name: irrelevant
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition

--- a/infrastructure/bootstrap/crds/kustomization.yaml
+++ b/infrastructure/bootstrap/crds/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- cert-manager/
+- cloudnative-pg/
+- external-secrets/
+- metallb/
+- prometheus-operator/
+- traefik/
+
+patches:
+###########################################################
+# drop all resource kinds except CRDs
+###########################################################
+# yamllint disable-line rule:indentation
+- patch: |-
+    $patch: delete
+    kind: irrelevant
+    metadata:
+      name: irrelevant
+  target:
+    kind: "(ConfigMap|ClusterRole|ClusterRoleBinding|Deployment|MutatingWebhookConfiguration|Namespace|Role|RoleBinding|Secret|Service|ServiceAccount|ValidatingWebhookConfiguration)"

--- a/infrastructure/bootstrap/crds/metallb/kustomization.yaml
+++ b/infrastructure/bootstrap/crds/metallb/kustomization.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- https://github.com/metallb/metallb//config/crd?ref=v0.14.8
+
+###########################################################
+# allow these CRDs to be adopted by Flux HelmRelease
+###########################################################
+patches:
+# yamllint disable-line rule:indentation
+- patch: |-
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        meta.helm.sh/release-name: metallb
+        meta.helm.sh/release-namespace: metallb-system
+      labels:
+        app.kubernetes.io/managed-by: Helm
+        helm.toolkit.fluxcd.io/name: metallb-release
+        helm.toolkit.fluxcd.io/namespace: flux-system
+      name: irrelevant
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition

--- a/infrastructure/bootstrap/crds/prometheus-operator/kustomization.yaml
+++ b/infrastructure/bootstrap/crds/prometheus-operator/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+# renovate-gh-release-asset: datasource=github-releases depName=prometheus-operator/prometheus-operator
+- https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.75.2/stripped-down-crds.yaml
+
+###########################################################
+# allow these CRDs to be adopted by Flux HelmRelease
+###########################################################
+patches:
+# yamllint disable-line rule:indentation
+- patch: |-
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        meta.helm.sh/release-name: kube-prometheus-stack
+        meta.helm.sh/release-namespace: monitoring
+      labels:
+        app.kubernetes.io/managed-by: Helm
+        helm.toolkit.fluxcd.io/name: kube-prometheus-stack-release
+        helm.toolkit.fluxcd.io/namespace: flux-system
+      name: irrelevant
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition

--- a/infrastructure/bootstrap/crds/traefik/kustomization.yaml
+++ b/infrastructure/bootstrap/crds/traefik/kustomization.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- https://github.com/traefik/traefik-helm-chart//traefik/crds?ref=v30.1.0
+
+###########################################################
+# allow these CRDs to be adopted by Flux HelmRelease
+###########################################################
+patches:
+# yamllint disable-line rule:indentation
+- patch: |-
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        meta.helm.sh/release-name: traefik
+        meta.helm.sh/release-namespace: traefik
+      labels:
+        app.kubernetes.io/managed-by: Helm
+        helm.toolkit.fluxcd.io/name: traefik-release
+        helm.toolkit.fluxcd.io/namespace: flux-system
+      name: irrelevant
+  target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition

--- a/infrastructure/bootstrap/kustomization.yaml
+++ b/infrastructure/bootstrap/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- crds/

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,10 +16,11 @@
   "draft": false,
   "initial-version": "0.0.1",
   "packages": {
-    ".": {
+    "infrastructure/bootstrap/crds": {
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "extra-label": "pr-type:release"
+      "component": "infra-bootstrap-crds",
+      "extra-label": "pr-type:release,subsystem:infra-bootstrap-crds"
     }
   },
   "prerelease": false,


### PR DESCRIPTION
infra-bootstrap-crds subsystems contains CRDs that should be installed on a kubernetes cluster when it's being setup and bootstrapped for the first time. Then other kubernetes manifests can contain resource definitions using these CRDs.

Subsequent updates to these CRDs will be managed by their corresponding Flux HelmRelease(s). These CRDs have been patched with the necessary labels + annotations so that they can be adopted by a Flux HelmRelease.