### PR TITLE
feat(infra-networking-core): add subsystem - infra-networking-core

### DIFF
--- a/.github/workflows/test-infrastructure-networking.yaml
+++ b/.github/workflows/test-infrastructure-networking.yaml
@@ -49,10 +49,6 @@ jobs:
           namespace: metallb-system
           for: jsonpath={.metadata.creationTimestamp}
           timeout: 1m
-        - resource: IPAddressPool/unifi-pool
-          namespace: metallb-system
-          for: jsonpath={.metadata.creationTimestamp}
-          timeout: 1m
         - resource: deployment/cert-manager
           namespace: cert-manager
           for: condition=available

--- a/.github/workflows/test-infrastructure-networking.yaml
+++ b/.github/workflows/test-infrastructure-networking.yaml
@@ -1,0 +1,149 @@
+---
+# yamllint disable rule:line-length
+name: test-infrastructure-networking
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    paths:
+    - '.github/workflows/test-infrastructure-networking.yaml'
+    - '.github/workflows/test-kubernetes-resources-workflow.yaml'
+    - '.github/kind-cluster-single-node.yaml'
+    - 'ci/test/infra-networking/**.yaml'
+    - 'infrastructure/subsystems/networking-core/**.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-infrastructure-networking:
+    uses: ./.github/workflows/test-kubernetes-resources-workflow.yaml
+    with:
+      test_path: ./ci/test/infra-networking
+      # yamllint disable-line rule:indentation
+      reconcile_items: |-
+        - name: infra-networking-core
+          kind: kustomization
+          namespace: flux-system
+          timeout: 5m
+      # yamllint disable-line rule:indentation
+      success_conditions: |-
+        - resource: deployment/metallb-controller
+          namespace: metallb-system
+          for: condition=available
+          timeout: 1m
+        - resource: daemonset/metallb-speaker
+          namespace: metallb-system
+          timeout: 1m
+        - resource: L2Advertisement/l2-advertisement
+          namespace: metallb-system
+          for: jsonpath={.metadata.creationTimestamp}
+          timeout: 1m
+        - resource: IPAddressPool/standard-pool
+          namespace: metallb-system
+          for: jsonpath={.metadata.creationTimestamp}
+          timeout: 1m
+        - resource: IPAddressPool/pihole-pool
+          namespace: metallb-system
+          for: jsonpath={.metadata.creationTimestamp}
+          timeout: 1m
+        - resource: IPAddressPool/unifi-pool
+          namespace: metallb-system
+          for: jsonpath={.metadata.creationTimestamp}
+          timeout: 1m
+        - resource: deployment/cert-manager
+          namespace: cert-manager
+          for: condition=available
+          timeout: 1m
+        - resource: deployment/cert-manager-cainjector
+          namespace: cert-manager
+          for: condition=available
+          timeout: 1m
+        - resource: deployment/cert-manager-webhook
+          namespace: cert-manager
+          for: condition=available
+          timeout: 1m
+        - resource: clusterissuer/selfsigned-issuer
+          namespace: "-"
+          for: condition=ready
+          timeout: 1m
+        - resource: certificate/selfsigned-tls-cert
+          namespace: traefik
+          for: condition=ready
+          timeout: 1m
+        - resource: daemonset/traefik
+          namespace: traefik
+          timeout: 1m
+        - resource: deployment/whoami
+          namespace: traefik
+          for: condition=available
+          timeout: 1m
+        - resource: service/traefik
+          namespace: traefik
+          for: jsonpath={.status.loadBalancer.ingress}
+          timeout: 1m
+        - resource: middleware/header-forwarded
+          namespace: traefik
+          for: jsonpath={.metadata.creationTimestamp}
+          timeout: 1m
+        - resource: middleware/redirect
+          namespace: traefik
+          for: jsonpath={.metadata.creationTimestamp}
+          timeout: 1m
+        - resource: tlsstore/default
+          namespace: traefik
+          for: jsonpath={.metadata.creationTimestamp}
+          timeout: 1m
+        - resource: tlsoption/default
+          namespace: traefik
+          for: jsonpath={.metadata.creationTimestamp}
+          timeout: 1m
+        - resource: serverstransport/insecure-skip-verify
+          namespace: traefik
+          for: jsonpath={.metadata.creationTimestamp}
+          timeout: 1m
+        - resource: deployment/cloudflared-doh
+          namespace: pihole
+          for: condition=available
+          timeout: 1m
+        - resource: deployment/unbound
+          namespace: pihole
+          for: condition=available
+          timeout: 1m
+        - resource: persistentvolumeclaim/pihole-data
+          namespace: pihole
+          for: jsonpath={.status.phase}=Bound
+          timeout: 1m
+        - resource: deployment/pihole
+          namespace: pihole
+          for: condition=available
+          timeout: 1m
+        - resource: service/pihole-dns-tcp
+          namespace: pihole
+          for: jsonpath={.status.loadBalancer.ingress}
+          timeout: 1m
+        - resource: service/pihole-dns-udp
+          namespace: pihole
+          for: jsonpath={.status.loadBalancer.ingress}
+          timeout: 1m
+        - resource: ingress/pihole-admin-https
+          namespace: pihole
+          for: jsonpath={.status.loadBalancer.ingress}
+          timeout: 1m
+        - resource: ingress/pihole-adblock-http
+          namespace: pihole
+          for: jsonpath={.status.loadBalancer.ingress}
+          timeout: 1m
+        - resource: ingress/pihole-adblock-https
+          namespace: pihole
+          for: jsonpath={.status.loadBalancer.ingress}
+          timeout: 1m
+        - resource: deployment/external-dns
+          namespace: external-dns
+          for: condition=available
+          timeout: 1m
+      git_url: https://github.com/${{ github.repository }}.git
+      git_ref: ${{ github.head_ref || github.ref }}
+      kind_cluster_config: kind-cluster-single-node.yaml

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,7 @@
 {
   "infrastructure/bootstrap/crds": "0.0.0",
   "infrastructure/helm-repositories": "0.0.0",
+  "infrastructure/subsystems/networking-core": "0.0.0",
   "infrastructure/subsystems/secrets-core": "0.0.0",
   "infrastructure/subsystems/storage-core": "0.0.0"
 }

--- a/ci/diff/infra.yaml
+++ b/ci/diff/infra.yaml
@@ -13,6 +13,8 @@ spec:
       name: cluster-common-conf
     - kind: ConfigMap
       name: cluster-storage-conf
+    - kind: ConfigMap
+      name: cluster-networking-conf
   prune: true
   sourceRef:
     kind: GitRepository

--- a/ci/test-data/config/cluster-networking-conf.yaml
+++ b/ci/test-data/config/cluster-networking-conf.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-networking-conf
+  namespace: flux-system
+data:
+  metallb_standard_ip_pool: 10.112.0.0/24
+  pihole_external_ip_address: 10.112.1.1
+  unifi_external_ip_address: 10.112.1.2

--- a/ci/test-data/config/kustomization.yaml
+++ b/ci/test-data/config/kustomization.yaml
@@ -5,7 +5,9 @@ kind: Kustomization
 resources:
 - cluster-common-conf.yaml
 - cluster-storage-conf.yaml
+- cluster-networking-conf.yaml
 - minio.yaml
+- pihole.yaml
 
 sortOptions:
   order: fifo

--- a/ci/test-data/config/pihole.yaml
+++ b/ci/test-data/config/pihole.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pihole-optional-config
+  namespace: pihole
+data:
+  DNSMASQ_LISTENING: all
+  DNSSEC: "false"
+  FTLCONF_MAXDBDAYS: "30"
+  FTLCONF_MOZILLA_CANARY: "true"
+  FTLCONF_RESOLVE_IPV6: "yes"
+  IPv6: "true"
+  REV_SERVER: "true"
+  REV_SERVER_CIDR: 10.112.0.0/16
+  REV_SERVER_DOMAIN: hosts.example.com
+  REV_SERVER_TARGET: 10.112.0.1
+  TZ: US/Eastern
+  WEBTHEME: default-darker
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: unbound-optional-config
+  namespace: pihole
+data:
+  # unbound requires running under root when deployed within kind,
+  # but does not require it when deployed within k3s
+  DISABLE_SET_PERMS: "true"

--- a/ci/test-data/namespaces.yaml
+++ b/ci/test-data/namespaces.yaml
@@ -2,4 +2,19 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: cert-manager
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-dns
+---
+apiVersion: v1
+kind: Namespace
+metadata:
   name: minio
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pihole

--- a/ci/test-data/secrets/cert-manager.yaml
+++ b/ci/test-data/secrets/cert-manager.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cert-manager-secrets
+  namespace: cert-manager
+type: Opaque
+stringData:
+  values.yaml: |
+    # Setting Nameservers for DNS01 Self Check
+    # See: https://cert-manager.io/docs/configuration/acme/dns01/#setting-nameservers-for-dns01-self-check
+    # Comma separated string with host and port of the recursive nameservers cert-manager should query
+    dns01RecursiveNameservers: "1.1.1.1:53"
+    dns01RecursiveNameserversOnly: true

--- a/ci/test-data/secrets/external-dns.yaml
+++ b/ci/test-data/secrets/external-dns.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: external-dns-secrets
+  namespace: external-dns
+type: Opaque
+stringData:
+  pihole_password: example

--- a/ci/test-data/secrets/pihole.yaml
+++ b/ci/test-data/secrets/pihole.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pihole-secrets
+  namespace: pihole
+type: Opaque
+stringData:
+  pihole_password: example

--- a/ci/test/infra-networking/infra-networking-core.yaml
+++ b/ci/test/infra-networking/infra-networking-core.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-networking-core
+  namespace: flux-system
+spec:
+  interval: 15m0s
+  path: ./infrastructure/subsystems/networking-core
+  postBuild:
+    substituteFrom:
+    - kind: ConfigMap
+      name: cluster-common-conf
+    - kind: ConfigMap
+      name: cluster-networking-conf
+  prune: false
+  sourceRef:
+    kind: GitRepository
+    name: test-source
+    namespace: flux-system
+  timeout: 2m0s
+  wait: true
+  patches:
+  # yamllint disable-line rule:indentation
+  - patch: |-
+      apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      metadata:
+        name: irrelevant
+      spec:
+        postBuild:
+          substituteFrom:
+          - kind: ConfigMap
+            name: cluster-common-conf
+          - kind: ConfigMap
+            name: cluster-networking-conf
+        sourceRef:
+          kind: GitRepository
+          name: test-source
+          namespace: flux-system
+    target:
+      group: kustomize.toolkit.fluxcd.io
+      kind: Kustomization

--- a/ci/test/infra-networking/kustomization.yaml
+++ b/ci/test/infra-networking/kustomization.yaml
@@ -3,10 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- cert-manager.yaml
-- external-dns.yaml
-- minio.yaml
-- pihole.yaml
+- infra-networking-core.yaml
 
 sortOptions:
   order: fifo

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -40,6 +40,7 @@ module.exports = {
         'release',
         'infra-bootstrap-crds',
         'infra-helm-repositories',
+        'infra-networking-core',
         'infra-secrets-core',
         'infra-storage-core'
       ]

--- a/infrastructure/subsystems/networking-core/cert-manager/helm-release.yaml
+++ b/infrastructure/subsystems/networking-core/cert-manager/helm-release.yaml
@@ -1,0 +1,119 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cert-manager-release
+  namespace: cert-manager
+spec:
+  chart:
+    spec:
+      chart: cert-manager
+      interval: 24h0m0s
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: cert-manager-repository
+        namespace: flux-system
+      version: v1.15.3
+  install:
+    crds: CreateReplace
+    createNamespace: false
+    remediation:
+      retries: 3
+  interval: 15m0s
+  releaseName: cert-manager
+  targetNamespace: cert-manager
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      ignoreTestFailures: false
+      retries: 3
+      strategy: rollback
+  valuesFrom:
+  - kind: Secret
+    name: cert-manager-secrets
+  values:
+    crds:
+      enabled: true
+
+    affinity:
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: In
+              values:
+              - "true"
+    resources: {}
+      # requests:
+      #   cpu: 10m
+      #   memory: 32Mi
+    tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+
+    cainjector:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: In
+                values:
+                - "true"
+      resources: {}
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+    webhook:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: In
+                values:
+                - "true"
+      resources: {}
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+    startupapicheck:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: In
+                values:
+                - "true"
+      resources: {}
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+
+    prometheus:
+      enabled: true
+      servicemonitor:
+        enabled: true
+      podmonitor:
+        enabled: false
+
+    extraObjects:
+    # yamllint disable-line rule:indentation
+    - |
+      apiVersion: cert-manager.io/v1
+      kind: ClusterIssuer
+      metadata:
+        name: selfsigned-issuer
+      spec:
+        selfSigned: {}

--- a/infrastructure/subsystems/networking-core/cert-manager/kustomization.yaml
+++ b/infrastructure/subsystems/networking-core/cert-manager/kustomization.yaml
@@ -3,10 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- cert-manager.yaml
-- external-dns.yaml
-- minio.yaml
-- pihole.yaml
+- helm-release.yaml
 
 sortOptions:
   order: fifo

--- a/infrastructure/subsystems/networking-core/external-dns/helm-release.yaml
+++ b/infrastructure/subsystems/networking-core/external-dns/helm-release.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-dns-release
+  namespace: external-dns
+spec:
+  chart:
+    spec:
+      chart: external-dns
+      interval: 24h0m0s
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: external-dns-repository
+        namespace: flux-system
+      version: 1.15.0
+  install:
+    crds: CreateReplace
+    createNamespace: false
+    remediation:
+      retries: 3
+  interval: 15m0s
+  releaseName: external-dns
+  targetNamespace: external-dns
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      ignoreTestFailures: false
+      retries: 3
+      strategy: rollback
+  values:
+    env:
+    - name: EXTERNAL_DNS_PIHOLE_SERVER
+      value: http://pihole-web.pihole.svc.cluster.local
+    - name: EXTERNAL_DNS_PIHOLE_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: external-dns-secrets
+          key: pihole_password
+          optional: false
+    sources:
+    - ingress
+    # IMPORTANT: If you have records that you manage manually in Pi-hole, set
+    # the policy to upsert-only so they do not get deleted.
+    policy: sync
+    # Pihole only supports A/CNAME records so there is no mechanism to track ownership.
+    # You don't need to set this flag, but if you leave it unset, you will receive warning
+    # logs when ExternalDNS attempts to create TXT records.
+    registry: noop
+    provider: pihole
+
+    resources: {}
+    affinity:
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+            - key: node-role.kubernetes.io/control-plane
+              operator: In
+              values:
+              - "true"
+    tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+
+    serviceMonitor:
+      enabled: true

--- a/infrastructure/subsystems/networking-core/external-dns/kustomization.yaml
+++ b/infrastructure/subsystems/networking-core/external-dns/kustomization.yaml
@@ -3,10 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- cert-manager.yaml
-- external-dns.yaml
-- minio.yaml
-- pihole.yaml
+- helm-release.yaml
 
 sortOptions:
   order: fifo

--- a/infrastructure/subsystems/networking-core/kustomization.yaml
+++ b/infrastructure/subsystems/networking-core/kustomization.yaml
@@ -3,10 +3,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- cert-manager.yaml
-- external-dns.yaml
-- minio.yaml
-- pihole.yaml
+- namespace.yaml
+- cert-manager/
+- metallb/
+- pihole/
+- external-dns/
+- traefik/
 
 sortOptions:
   order: fifo

--- a/infrastructure/subsystems/networking-core/metallb/helm-release.yaml
+++ b/infrastructure/subsystems/networking-core/metallb/helm-release.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: metallb-release
+  namespace: metallb-system
+spec:
+  chart:
+    spec:
+      chart: metallb
+      interval: 24h0m0s
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: metallb-repository
+        namespace: flux-system
+      version: 0.14.8
+  install:
+    crds: CreateReplace
+    createNamespace: false
+    remediation:
+      retries: 3
+  interval: 15m0s
+  releaseName: metallb
+  targetNamespace: metallb-system
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      ignoreTestFailures: false
+      retries: 3
+      strategy: rollback
+  values:
+    crds:
+      enabled: true
+
+    controller:
+      logLevel: info
+      resources: {}
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: In
+                values:
+                - "true"
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+
+    speaker:
+      logLevel: info
+      resources: {}
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: In
+                values:
+                - "true"
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+
+    prometheus:
+      rbacPrometheus: false
+      podMonitor:
+        enabled: false
+      serviceMonitor:
+        enabled: true
+      prometheusRule:
+        enabled: true

--- a/infrastructure/subsystems/networking-core/metallb/ipaddresspool.yaml
+++ b/infrastructure/subsystems/networking-core/metallb/ipaddresspool.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: standard-pool
+  namespace: metallb-system
+spec:
+  addresses:
+  - ${metallb_standard_ip_pool}
+  avoidBuggyIPs: true

--- a/infrastructure/subsystems/networking-core/metallb/kustomization.yaml
+++ b/infrastructure/subsystems/networking-core/metallb/kustomization.yaml
@@ -3,10 +3,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- cert-manager.yaml
-- external-dns.yaml
-- minio.yaml
-- pihole.yaml
+- helm-release.yaml
+- ipaddresspool.yaml
+- l2advertisement.yaml
 
 sortOptions:
   order: fifo

--- a/infrastructure/subsystems/networking-core/metallb/l2advertisement.yaml
+++ b/infrastructure/subsystems/networking-core/metallb/l2advertisement.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: l2-advertisement
+  namespace: metallb-system

--- a/infrastructure/subsystems/networking-core/namespace.yaml
+++ b/infrastructure/subsystems/networking-core/namespace.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    kustomize.toolkit.fluxcd.io/ssa: merge
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-dns
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    kustomize.toolkit.fluxcd.io/ssa: merge
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metallb-system
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    kustomize.toolkit.fluxcd.io/ssa: merge
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pihole
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    kustomize.toolkit.fluxcd.io/ssa: merge
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: traefik
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    kustomize.toolkit.fluxcd.io/ssa: merge
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/infrastructure/subsystems/networking-core/pihole/cloudflared-doh/deployment.yaml
+++ b/infrastructure/subsystems/networking-core/pihole/cloudflared-doh/deployment.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudflared-doh
+  namespace: pihole
+  labels:
+    app.kubernetes.io/name: cloudflared-doh
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cloudflared-doh
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cloudflared-doh
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - name: cloudflared-doh
+        env:
+        - name: PORT
+          value: "53"
+        - name: UPSTREAM1
+          value: https://1.1.1.2/dns-query
+        - name: UPSTREAM2
+          value: https://1.0.0.2/dns-query
+        - name: METRICS
+          value: 0.0.0.0:8080
+        - name: MAX_UPSTREAM_CONNS
+          value: "5"
+        image: visibilityspots/cloudflared:v2024.9.1@sha256:ec8e57ef185fca03814027dc3a3c838c75159864130dc6bb3fba49cc82b8faa2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          tcpSocket:
+            port: 53
+          initialDelaySeconds: 5
+          periodSeconds: 15
+        ports:
+        - name: doh-tcp
+          containerPort: 53
+          protocol: TCP
+        - name: doh-udp
+          containerPort: 53
+          protocol: UDP
+        - name: doh-metrics
+          containerPort: 8080
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command: [dig, +short, +retry=0, '@127.0.0.1', cloudflare.com]
+          initialDelaySeconds: 5
+          periodSeconds: 60
+          timeoutSeconds: 10
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+      dnsConfig:
+        nameservers:
+        - 127.0.0.1
+        - ${dns_fallback:=1.1.1.1}
+      dnsPolicy: None
+      hostname: cloudflared-doh
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: In
+                values:
+                - "true"
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists

--- a/infrastructure/subsystems/networking-core/pihole/cloudflared-doh/kustomization.yaml
+++ b/infrastructure/subsystems/networking-core/pihole/cloudflared-doh/kustomization.yaml
@@ -3,10 +3,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- cert-manager.yaml
-- external-dns.yaml
-- minio.yaml
-- pihole.yaml
+- deployment.yaml
+- service.yaml
 
 sortOptions:
   order: fifo

--- a/infrastructure/subsystems/networking-core/pihole/cloudflared-doh/service.yaml
+++ b/infrastructure/subsystems/networking-core/pihole/cloudflared-doh/service.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cloudflared-doh
+  namespace: pihole
+  labels:
+    app.kubernetes.io/name: cloudflared-doh
+spec:
+  selector:
+    app.kubernetes.io/name: cloudflared-doh
+  ports:
+  - name: doh-tcp
+    port: 53
+    targetPort: doh-tcp
+    protocol: TCP
+  - name: doh-udp
+    port: 53
+    targetPort: doh-udp
+    protocol: UDP
+  type: ClusterIP

--- a/infrastructure/subsystems/networking-core/pihole/kustomization.yaml
+++ b/infrastructure/subsystems/networking-core/pihole/kustomization.yaml
@@ -3,10 +3,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- cert-manager.yaml
-- external-dns.yaml
-- minio.yaml
-- pihole.yaml
+- cloudflared-doh/
+- unbound/
+- pihole/
 
 sortOptions:
   order: fifo

--- a/infrastructure/subsystems/networking-core/pihole/pihole/deployment.yaml
+++ b/infrastructure/subsystems/networking-core/pihole/pihole/deployment.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pihole
+  namespace: pihole
+  labels:
+    app.kubernetes.io/name: pihole
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pihole
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pihole
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - name: pihole
+        command: [/bin/bash, /scripts/entrypoint.sh]
+        env:
+        - name: DHCP_ACTIVE
+          value: "false"
+        - name: DNSMASQ_USER
+          value: pihole
+        - name: FTLCONF_LOCAL_IPV4
+          value: ${pihole_external_ip_address}
+        - name: VIRTUAL_HOST
+          value: pihole.${domain_name}
+        - name: WEBPASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: pihole_password
+              name: pihole-secrets
+              optional: false
+        envFrom:
+        - configMapRef:
+            name: pihole-optional-config
+            optional: true
+        image: pihole/pihole:2024.07.0@sha256:0def896a596e8d45780b6359dbf82fc8c75ef05b97e095452e67a0a4ccc95377
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          exec:
+            command: [/bin/bash, --norc, --noprofile, /scripts/liveness-probe.sh]
+          periodSeconds: 15
+        ports:
+        - name: pihole-web
+          containerPort: 80
+          protocol: TCP
+        - name: pihole-dns-tcp
+          containerPort: 53
+          protocol: TCP
+        - name: pihole-dns-udp
+          containerPort: 53
+          protocol: UDP
+        - name: pihole-dhcp
+          containerPort: 67
+          protocol: TCP
+        readinessProbe:
+          exec:
+            command: [dig, +short, +norecurse, +retry=0, '@127.0.0.1', pi.hole]
+          periodSeconds: 60
+        startupProbe:
+          exec:
+            command: [/bin/bash, --norc, --noprofile, /scripts/liveness-probe.sh]
+          failureThreshold: 24
+          initialDelaySeconds: 10
+          periodSeconds: 5
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            - SYS_NICE
+            - CHOWN
+            drop:
+            - NET_RAW
+        volumeMounts:
+        - mountPath: /etc/pihole
+          name: pihole-data
+          subPath: pihole
+        - mountPath: /etc/dnsmasq.d
+          name: pihole-data
+          subPath: dnsmasq.d
+        - mountPath: /scripts
+          name: pihole-scripts
+        - mountPath: /var/log/pihole
+          name: pihole-logs
+      dnsConfig:
+        nameservers:
+        - 127.0.0.1
+        - ${dns_fallback:=1.1.1.1}
+      dnsPolicy: None
+      hostname: pihole
+      volumes:
+      - name: pihole-data
+        persistentVolumeClaim:
+          claimName: pihole-data
+      - name: pihole-scripts
+        configMap:
+          name: pihole-scripts
+      - name: pihole-logs
+        # pihole writes logs to multiple different log files:
+        #     FTL.log  pihole.log  pihole_updateGravity.log
+        # these are not written to stdout, so we are placing them on the host,
+        # so that we can configure promtail to collect them.
+        hostPath:
+          path: /var/log/pihole
+          type: DirectoryOrCreate
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: In
+                values:
+                - "true"
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists

--- a/infrastructure/subsystems/networking-core/pihole/pihole/ingress.yaml
+++ b/infrastructure/subsystems/networking-core/pihole/pihole/ingress.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: pihole-admin-https
+  namespace: pihole
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: pihole.${domain_name}
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+spec:
+  # setting tls to [], so that default certficate will be assigned
+  tls: []
+  rules:
+  - host: pihole.${domain_name}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: pihole-web
+            port:
+              number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: pihole-adblock-https
+  namespace: pihole
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+spec:
+  # setting tls to [], so that default certficate will be assigned
+  tls: []
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: pihole-web
+            port:
+              number: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: pihole-adblock-http
+  namespace: pihole
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+    traefik.ingress.kubernetes.io/router.tls: "false"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: pihole-web
+            port:
+              number: 80

--- a/infrastructure/subsystems/networking-core/pihole/pihole/ipaddresspool.yaml
+++ b/infrastructure/subsystems/networking-core/pihole/pihole/ipaddresspool.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: pihole-pool
+  namespace: metallb-system
+spec:
+  addresses:
+  - ${pihole_external_ip_address}/32
+  avoidBuggyIPs: true
+  serviceAllocation:
+    namespaces:
+    - pihole
+    serviceSelectors:
+    - matchLabels:
+        app.kubernetes.io/name: pihole
+    - matchExpressions:
+      - key: app.kubernetes.io/component
+        operator: In
+        values:
+        - dns-tcp
+        - dns-udp

--- a/infrastructure/subsystems/networking-core/pihole/pihole/kustomization.yaml
+++ b/infrastructure/subsystems/networking-core/pihole/pihole/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ipaddresspool.yaml
+- pvc.yaml
+- deployment.yaml
+- service.yaml
+- ingress.yaml
+
+configMapGenerator:
+- name: pihole-scripts
+  namespace: pihole
+  files:
+  - scripts/entrypoint.sh
+  - scripts/liveness-probe.sh
+  options:
+    annotations:
+      kustomize.toolkit.fluxcd.io/substitute: disabled
+
+sortOptions:
+  order: fifo

--- a/infrastructure/subsystems/networking-core/pihole/pihole/pvc.yaml
+++ b/infrastructure/subsystems/networking-core/pihole/pihole/pvc.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pihole-data
+  namespace: pihole
+  labels:
+    app.kubernetes.io/name: pihole
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+spec:
+  accessModes:
+  - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 2Gi

--- a/infrastructure/subsystems/networking-core/pihole/pihole/scripts/entrypoint.sh
+++ b/infrastructure/subsystems/networking-core/pihole/pihole/scripts/entrypoint.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+set -eo pipefail
+
+UPSTREAM_PORT="53"
+
+
+retry() {
+  local -r -i max_attempts="$1"; shift
+  # shellcheck disable=SC2124
+  local -r cmd="$@"
+  local -i attempt=1
+
+  until /usr/bin/timeout -v 3s $cmd 2>&1; do
+    if (( attempt == max_attempts )); then
+      echo "Attempt $attempt failed and there are no more attempts left!"
+      return 1
+    fi
+
+    local sleep_seconds=$(( attempt ** 2 ))
+    echo "Attempt $attempt failed! Trying again in $sleep_seconds seconds..."
+    attempt=$(( attempt + 1 ))
+    sleep $sleep_seconds
+  done
+}
+
+wait_till_upstream() {
+  local -r upstream_host="$1"
+  local -r upstream_name="$2"
+
+  echo "Checking connectivity..."
+  if retry 3 nc -z -v -w 1 $upstream_host $UPSTREAM_PORT 2>&1 | sed -E 's|(.*)|    \1|g'; then
+    echo "Checking dns resolution..."
+    retry 3 dig @$upstream_host cloudflare.com | sed -E 's|(.*)|    \1|g'
+    echo "Upstream $upstream_name is resolving dns successfully..."
+  else
+    echo "Cannot connect to upstream $upstream_name ($upstream_host)."
+    return 1
+  fi
+}
+
+validate_and_set_upstream() {
+  local -r upstream_host="$1"
+  local -r upstream_name="$2"
+  local -r upstream_type="$3"
+
+  echo "upstream/($upstream_type): $upstream_name ($upstream_host):"
+  echo "  Upstream dns service configured by kubrnetes service discovery at this service IP..."
+  echo "  Adding upstream to /etc/hosts..."
+  echo -e "$upstream_host\t$upstream_name" >> /etc/hosts
+  echo $upstream_host > /var/run/pihole/__upstream_$upstream_type
+  echo "  Validating upstream dns service..."
+  if wait_till_upstream $upstream_host $upstream_name 2>&1 | sed -E 's|(.*)|    \1|g'; then
+    if [[ -e /var/run/pihole/__upstream_current ]]; then
+      echo "  An upstream has already been set, skipping for this upstream..."
+    else
+      echo "  No upstream has been set yet..."
+      echo "  Directing pihole to use $upstream_type upstream ($upstream_name)..."
+      ln -sf /var/run/pihole/__upstream_$upstream_type /var/run/pihole/__upstream_current
+      export PIHOLE_DNS_="${upstream_host}"
+      echo "  Done."
+    fi
+  else
+    return 1
+  fi
+}
+
+configure_upstream() {
+  local -i upstream_count=0
+
+  if [[ ! -z "${UNBOUND_SERVICE_HOST}" ]]; then
+    if validate_and_set_upstream "${UNBOUND_SERVICE_HOST}" "unbound-recursive" "primary"; then
+      upstream_count=$((upstream_count+1))
+    fi
+  fi
+  echo
+  if [[ ! -z "${CLOUDFLARED_DOH_SERVICE_HOST}" ]]; then
+    if validate_and_set_upstream "${CLOUDFLARED_DOH_SERVICE_HOST}" "cloudflare-doh" "secondary"; then
+      upstream_count=$((upstream_count+1))
+    fi
+  fi
+  echo
+  echo "$upstream_count upstreams are available..."
+  if (( upstream_count == 0 )); then
+    echo "All upstreams failed validation..."
+    echo "Cannot proceed without an upstream DNS server..."
+    echo "Exiting..."
+    echo
+    exit 1
+  fi
+}
+
+main() {
+  echo "Detecting and configuring pihole upstream based on kubernetes service env vars..."
+  echo
+  configure_upstream
+  echo
+  if [[ ! -z "${REV_SERVER_TARGET}" ]]; then
+    echo "Configuring router ($REV_SERVER_TARGET) in /etc/hosts..."
+    echo -e "$REV_SERVER_TARGET\trouter" >> /etc/hosts
+    echo
+  fi
+  echo "Starting pihole..."
+  exec /s6-init
+}
+
+main

--- a/infrastructure/subsystems/networking-core/pihole/pihole/scripts/liveness-probe.sh
+++ b/infrastructure/subsystems/networking-core/pihole/pihole/scripts/liveness-probe.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# For the liveness probe, we're testing 2 things:
+#   1) dns resolution by upstream server
+#   2) dns resolution by pihole itself
+# If either fails, we want the pihole container to be restarted.
+#   1) restarting when upstream dns resolution fails,
+#      - allows kubernetes to set the upstream server's ip address as an environment variable
+#        for service discovery by entrypoint script.
+#      - so if upstream server's service ip changed, then this restart and reset of upstream host
+#        ip should fix that problem. a restart of this pod is only way, a new value will be set
+#        for that environment variable.
+#           See: https://kubernetes.io/docs/concepts/services-networking/service/#environment-variables
+#   2) additionally if pihole itself can't resolve DNS, then a restart could potentially
+#      solve that issue.
+
+UPSTREAM_HOST=$(cat /var/run/pihole/__upstream_current)
+dig +short +retry=0 @$UPSTREAM_HOST cloudflare.com
+dig +short +retry=0 +norecurse '@127.0.0.1' pi.hole

--- a/infrastructure/subsystems/networking-core/pihole/pihole/service.yaml
+++ b/infrastructure/subsystems/networking-core/pihole/pihole/service.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pihole-web
+  namespace: pihole
+  labels:
+    app.kubernetes.io/name: pihole
+spec:
+  selector:
+    app.kubernetes.io/name: pihole
+  ports:
+  - name: web
+    port: 80
+    targetPort: pihole-web
+    protocol: TCP
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pihole-dns-tcp
+  namespace: pihole
+  labels:
+    app.kubernetes.io/name: pihole
+    app.kubernetes.io/component: dns-tcp
+  annotations:
+    metallb.universe.tf/allow-shared-ip: dns
+    metallb.universe.tf/address-pool: pihole-pool
+spec:
+  selector:
+    app.kubernetes.io/name: pihole
+  externalTrafficPolicy: Local
+  ports:
+  - name: dns-tcp
+    port: 53
+    targetPort: pihole-dns-tcp
+    protocol: TCP
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pihole-dns-udp
+  namespace: pihole
+  labels:
+    app.kubernetes.io/name: pihole
+    app.kubernetes.io/component: dns-udp
+  annotations:
+    metallb.universe.tf/allow-shared-ip: dns
+    metallb.universe.tf/address-pool: pihole-pool
+spec:
+  selector:
+    app.kubernetes.io/name: pihole
+  externalTrafficPolicy: Local
+  ports:
+  - name: dns-tcp
+    port: 53
+    targetPort: pihole-dns-udp
+    protocol: UDP
+  type: LoadBalancer

--- a/infrastructure/subsystems/networking-core/pihole/unbound/conf.d/unbound.conf
+++ b/infrastructure/subsystems/networking-core/pihole/unbound/conf.d/unbound.conf
@@ -1,0 +1,497 @@
+server:
+    ###########################################################################
+    # BASIC SETTINGS
+    ###########################################################################
+
+    # Listen for queries on this network interface and port.
+    interface: 0.0.0.0@53
+
+    do-ip4: yes
+    do-ip6: no
+    do-udp: yes
+    do-tcp: yes
+    prefer-ip4: yes
+    prefer-ip6: no
+
+    # Use systemd socket activation for UDP, TCP, and control sockets.
+    use-systemd: no
+
+    # Detach from the terminal, run in background, "yes" or "no".
+    # Set the value to "no" when Unbound runs as systemd service.
+    do-daemonize: no
+
+    # if given, user privileges are dropped (after binding port),
+    # and the given username is assumed. Default is user "unbound".
+    # If you give "" no privileges are dropped.
+    username: ""
+
+    # the working directory. The relative files in this config are
+    # relative to this directory. If you give "" the working directory
+    # is not changed.
+    # If you give a server: directory: dir before include: file statements
+    # then those includes can be relative to the working directory.
+    directory: "/usr/local/unbound/"
+
+    # if given, a chroot(2) is done to the given directory.
+    # i.e. you can chroot to the working directory, for example,
+    # for extra security, but make sure all files are in that directory.
+    #
+    # If chroot is enabled, you should pass the configfile (from the
+    # commandline) as a full path from the original root. After the
+    # chroot has been performed the now defunct portion of the config
+    # file path is removed to be able to reread the config after a reload.
+    #
+    # All other file paths (working dir, logfile, roothints, and
+    # key files) can be specified in several ways:
+    # 	o as an absolute path relative to the new root.
+    # 	o as a relative path to the working directory.
+    # 	o as an absolute path relative to the original root.
+    # In the last case the path is adjusted to remove the unused portion.
+    #
+    # The pid file can be absolute and outside of the chroot, it is
+    # written just prior to performing the chroot and dropping permissions.
+    #
+    # Additionally, Unbound may need to access /dev/urandom (for entropy).
+    # How to do this is specific to your OS.
+    #
+    # If you give "" no chroot is performed. The path must not end in a /.
+    chroot: ""
+
+    # the pid file. Can be an absolute path outside of chroot/work dir.
+    pidfile: "/usr/local/unbound/unbound.d/unbound.pid"
+
+    # module configuration of the server. A string with identifiers
+    # separated by spaces. Syntax: "[dns64] [validator] iterator"
+    # most modules have to be listed at the beginning of the line,
+    # except cachedb(just before iterator), and python (at the beginning,
+    # or, just before the iterator).
+    module-config: "validator iterator"
+
+    # If you want to perform DNSSEC validation, run unbound-anchor before
+    # you start Unbound (i.e. in the system boot scripts).
+    # And then enable the auto-trust-anchor-file config item.
+    # Please note usage of unbound-anchor root anchor is at your own risk
+    # and under the terms of our LICENSE (see that file in the source).
+    auto-trust-anchor-file: "/usr/local/unbound/iana.d/root.key"
+
+    # trust anchor signaling sends a RFC8145 key tag query after priming.
+    trust-anchor-signaling: yes
+
+    # Use this certificate bundle for authenticating connections made to
+    # outside peers (e.g., auth-zone urls, DNS over TLS connections).
+    tls-cert-bundle: /etc/ssl/certs/ca-certificates.crt
+
+    # file to read root hints from.
+    # get one from https://www.internic.net/domain/named.cache
+    # root-hints: ""
+    # root-hints: "/usr/local/unbound/iana.d/root.hints"
+
+    ###########################################################################
+    # LOGGING
+    ###########################################################################
+
+    # the log file, "" means log to stderr.
+    # Use of this option sets use-syslog to "no".
+    logfile: ""
+
+    # log the local-zone actions, like local-zone type inform is enabled also for the other local zone types.
+    log-local-actions: yes
+
+    # print one line with time, IP, name, type, class for every query.
+    log-queries: yes
+
+    # print one line per reply, with time, IP, name, type, class, rcode, timetoresolve, fromcache and responsesize.
+    log-replies: yes
+
+    # print log lines that say why queries return SERVFAIL to clients.
+    log-servfail: yes
+
+    # print UTC timestamp in ascii to logfile, default is epoch in seconds.
+    log-time-ascii: yes
+
+    # Log to syslog(3) if yes. The log facility LOG_DAEMON is used to
+    # log to. If yes, it overrides the logfile.
+    use-syslog: no
+
+    # Have the validator log failed validations for your diagnosis.
+    # 0: off. 1: A line per failed user query. 2: With reason and bad IP.
+    val-log-level: 2
+
+    # Set logging level
+    # Level 0: No verbosity, only errors.
+    # Level 1: Gives operational information.
+    # Level 2: Gives detailed operational information including short information per query.
+    # Level 3: Gives query level information, output per query.
+    # Level 4: Gives algorithm level information.
+    # Level 5: Logs client identification for cache misses.
+    verbosity: 2
+
+    ###########################################################################
+    # PRIVACY SETTINGS
+    ###########################################################################
+
+    # RFC 8198. Use the DNSSEC NSEC chain to synthesize NXDO-MAIN and other
+    # denials, using information from previous NXDO-MAINs answers. In other
+    # words, use cached NSEC records to generate negative answers within a
+    # range and positive answers from wildcards. This increases performance,
+    # decreases latency and resource utilization on both authoritative and
+    # recursive servers, and increases privacy. Also, it may help increase
+    # resilience to certain DoS attacks in some circumstances.
+    aggressive-nsec: yes
+
+    # Do not query the following addresses. No DNS queries are sent there.
+    # List one address per entry. List classless netblocks with /size,
+    do-not-query-address: 127.0.0.1/8
+    do-not-query-address: ::1
+
+    # if yes, the above default do-not-query-address entries are present.
+    # if no, localhost can be queried (for testing and debugging).
+    do-not-query-localhost: yes
+
+    # The insecure-lan-zones option disables validation for
+    # these zones, as if they were all listed as domain-insecure.
+    insecure-lan-zones: yes
+
+    # Enforce privacy of these addresses. Strips them away from answers.
+    # It may cause DNSSEC validation to additionally mark it as bogus.
+    # Protects against 'DNS Rebinding' (uses browser as network proxy).
+    # Only 'private-domain' and 'local-data' names are allowed to have
+    # these private addresses. No default.
+    private-address: 10.0.0.0/8
+    private-address: 172.16.0.0/12
+    private-address: 192.168.0.0/16
+    private-address: 169.254.0.0/16
+    private-address: fd00::/8
+    private-address: fe80::/10
+    private-address: ::ffff:0:0/96
+
+    # Sent minimum amount of information to upstream servers to enhance
+    # privacy. Only sent minimum required labels of the QNAME and set QTYPE
+    # to A when possible.
+    qname-minimisation: yes
+
+    # QNAME minimisation in strict mode. Do not fall-back to sending full
+    # QNAME to potentially broken nameservers. A lot of domains will not be
+    # resolvable when this option in enabled.
+    # This option only has effect when qname-minimisation is enabled.
+    # qname-minimisation-strict: no
+
+    # If Unbound is running service for the local host then it is useful
+    # to perform lan-wide lookups to the upstream, and unblock the
+    # long list of local-zones above.  If this Unbound is a dns server
+    # for a network of computers, disabled is better and stops information
+    # leakage of local lan information.
+    unblock-lan-zones: no
+
+    ###########################################################################
+    # STATISTICS SETTINGS
+    ###########################################################################
+    # print statistics to the log (for every thread) every N seconds.
+    # Set to "" or 0 to disable. Default is disabled.
+    # statistics-interval: 0
+
+    # enable shm for stats, default no.  if you enable also enable
+    # statistics-interval, every time it also writes stats to the
+    # shared memory segment keyed with shm-key.
+    # shm-enable: no
+
+    # shm for stats uses this key, and key+1 for the shared mem segment.
+    # shm-key: 11777
+
+    # enable cumulative statistics, without clearing them after printing.
+    # statistics-cumulative: no
+
+    # enable extended statistics (query types, answer codes, status)
+    # printed from unbound-control. Default off, because of speed.
+    # extended-statistics: no
+
+    # Inhibits selected extended statistics (qtype, qclass, qopcode, rcode,
+    # rpz-actions) from printing if their value is 0.
+    # Default on.
+    # statistics-inhibit-zero: yes
+
+    ###########################################################################
+    # SECURITY SETTINGS
+    ###########################################################################
+    # Only give access to recursion clients from LAN IPs
+    access-control: 127.0.0.1/32 allow
+    access-control: 192.168.0.0/16 allow
+    access-control: 172.16.0.0/12 allow
+    access-control: 10.0.0.0/8 allow
+    # access-control: fc00::/7 allow
+    # access-control: ::1/128 allow
+
+    # Deny queries of type ANY with an empty response.
+    deny-any: yes
+
+    # true to disable DNSSEC lameness check in iterator.
+    disable-dnssec-lame-check: no
+
+    # Harden against algorithm downgrade when multiple algorithms are
+    # advertised in the DS record.
+    harden-algo-downgrade: yes
+
+    # RFC 8020. returns nxdomain to queries for a name below another name that
+    # is already known to be nxdomain.
+    harden-below-nxdomain: yes
+
+    # Require DNSSEC data for trust-anchored zones, if such data is absent, the
+    # zone becomes bogus. If turned off you run the risk of a downgrade attack
+    # that disables security for a zone.
+    harden-dnssec-stripped: yes
+
+    # Harden against out of zone rrsets, to avoid spoofing attempts.
+    harden-glue: yes
+
+    # Ignore unseemly large queries.
+    harden-large-queries: yes
+
+    # Perform additional queries for infrastructure data to harden the referral
+    # path. Validates the replies if trust anchors are configured and the zones
+    # are signed. This enforces DNSSEC validation on nameserver NS sets and the
+    # nameserver addresses that are encountered on the referral path to the
+    # answer. Experimental option.
+    harden-referral-path: yes
+
+    # Ignore very small EDNS buffer sizes from queries.
+    harden-short-bufsize: yes
+
+    # If enabled the HTTP header User-Agent is not set. Use with caution
+    # as some webserver configurations may reject HTTP requests lacking
+    # this header. If needed, it is better to explicitly set the
+    # the http-user-agent.
+    hide-http-user-agent: no
+
+    # Refuse id.server and hostname.bind queries
+    hide-identity: yes
+
+    # enable to not answer trustanchor.unbound queries.
+    hide-trustanchor: yes
+
+    # Set the HTTP User-Agent header for outgoing HTTP requests. If
+    # set to "", the default, then the package name and version are
+    # used.
+    http-user-agent: "DNS"
+
+    # Refuse version.server and version.bind queries
+    hide-version: yes
+
+    # Report this identity rather than the hostname of the server.
+    identity: "DNS"
+
+    # ratelimit for uncached, new queries, this limits recursion effort.
+    # ratelimiting is experimental, and may help against random query flood,
+    # but not spoofed reflection floods.
+    # if 0(default) it is disabled, otherwise state qps allowed per zone.
+    # ratelimit: 0
+
+    # Root key trust anchor sentinel (draft-ietf-dnsop-kskroll-sentinel)
+    root-key-sentinel: yes
+
+    # Set the total number of unwanted replies to keep track of in every thread.
+    # When it reaches the threshold, a defensive action of clearing the rrset
+    # and message caches is taken, hopefully flushing away any poison.
+    # Unbound suggests a value of 10 million.
+    unwanted-reply-threshold: 10000
+
+    # Use 0x20-encoded random bits in the query to foil spoof attempts. This
+    # perturbs the lowercase and uppercase of query names sent to authority
+    # servers and checks if the reply still has the correct casing.
+    # This feature is an experimental implementation of draft dns-0x20.
+    # Experimental option.
+    use-caps-for-id: yes
+
+    # Help protect users that rely on this validator for authentication from
+    # potentially bad data in the additional section. Instruct the validator to
+    # remove data from the additional section of secure messages that are not
+    # signed properly. Messages that are insecure, bogus, indeterminate or
+    # unchecked are not affected.
+    val-clean-additional: yes
+
+    ###########################################################################
+    # PERFORMANCE SETTINGS
+    ###########################################################################
+    # https://nlnetlabs.nl/documentation/unbound/howto-optimise/
+    # https://nlnetlabs.nl/news/2019/Feb/05/unbound-1.9.0-released/
+
+    # Time to live maximum for RRsets and messages in the cache. If the maximum
+    # kicks in, responses to clients still get decrementing TTLs based on the
+    # original (larger) values. When the internal TTL expires, the cache item
+    # has expired. Can be set lower to force the resolver to query for data
+    # often, and not trust (very large) TTL values.
+    cache-max-ttl: 86400
+
+    # Time to live minimum for RRsets and messages in the cache. If the minimum
+    # kicks in, the data is cached for longer than the domain owner intended,
+    # and thus less queries are made to look up the data. Zero makes sure the
+    # data in the cache is as the domain owner intended, higher values,
+    # especially more than an hour or so, can lead to trouble as the data in
+    # the cache does not match up with the actual data any more.
+    cache-min-ttl: 300
+
+    # Extra delay for timeouted UDP ports before they are closed, in msec.
+    # This prevents very delayed answer packets from the upstream (recursive)
+    # servers from bouncing against closed ports and setting off all sort of
+    # close-port counters, with eg. 1500 msec. When timeouts happen you need
+    # extra sockets, it checks the ID and remote IP of packets, and unwanted
+    # packets are added to the unwanted packet counter.
+    delay-close: 10000
+
+    # RFC 6891. Number  of bytes size to advertise as the EDNS reassembly buffer
+    # size. This is the value put into  datagrams over UDP towards peers.
+    # The actual buffer size is determined by msg-buffer-size (both for TCP and
+    # UDP). Do not set higher than that value.
+    # Default  is  1232 which is the DNS Flag Day 2020 recommendation.
+    # Setting to 512 bypasses even the most stringent path MTU problems, but
+    # is seen as extreme, since the amount of TCP fallback generated is
+    # excessive (probably also for this resolver, consider tuning the outgoing
+    # tcp number).
+    edns-buffer-size: 1232
+
+    # the number of slabs to use for the Infrastructure cache. the number of
+    # slabs must be a power of 2. more slabs reduce lock contention, but fragment
+    # memory usage.
+    infra-cache-slabs: 4
+
+    # the maximum number of hosts that are cached (roundtrip, EDNS, lame).
+    # infra-cache-numhosts: 10000
+
+    # minimum wait time for responses, increase if uplink is long. In msec.
+    # infra-cache-min-rtt: 50
+
+    # maximum wait time for responses. In msec.
+    # infra-cache-max-rtt: 120000
+
+    # the amount of memory to use for the key cache.
+    # plain value in bytes or you can append k, m or G. default is "4Mb".
+    key-cache-size: 4m
+
+    # the number of slabs to use for the key cache.
+    # the number of slabs must be a power of 2.
+    # more slabs reduce lock contention, but fragment memory usage.
+    key-cache-slabs: 4
+
+    # buffer size for handling DNS data. No messages larger than this
+    # size can be sent or received, by UDP or TCP. In bytes.
+    # msg-buffer-size: 65552
+
+    # the amount of memory to use for the message cache. unbound recommends setting
+    # to half of rrset-cache-size.
+    # plain value in bytes or you can append k, m or G. default is "4Mb".
+    msg-cache-size: 64m
+
+    # the number of slabs to use for the message cache. the number of slabs must
+    # be a power of 2. more slabs reduce lock contention, but fragment memory usage.
+    msg-cache-slabs: 4
+
+    # Do no insert authority/additional sections into response messages when
+    # those sections are not required. This reduces response size
+    # significantly, and may avoid TCP fallback for some responses. This may
+    # cause a slight speedup.
+    minimal-responses: yes
+
+    # Number  of  bytes size of the aggressive negative cache.
+    neg-cache-size: 4M
+
+    # The number of threads to create to serve clients. 1 disables threading.
+    num-threads: 2
+
+    # The number of queries that every thread will service simultaneously. If
+    # more queries arrive that need servicing, and no queries can be jostled
+    # out (see jostle-timeout), then the queries are dropped.
+    # This is best set at half the number of the outgoing-range.
+    # This Unbound instance was compiled with libevent so it can efficiently
+    # use more than 1024 file descriptors.
+    num-queries-per-thread: 4096
+
+    # Number of incoming TCP buffers to allocate per thread. Default
+    # is 10. If set to 0, or if do-tcp is "no", no  TCP  queries  from
+    # clients  are  accepted. For larger installations increasing this
+    # value is a good idea.
+    incoming-num-tcp: 10
+
+    # Number of slabs in the key cache. Slabs reduce lock contention by
+    # threads. Must be set to a power of 2. Setting (close) to the number
+    # of cpus is a reasonable guess.
+    key-cache-slabs: 4
+
+    # number of ports to allocate per thread, determines the size of the
+    # port range that can be open simultaneously.  About double the
+    # num-queries-per-thread, or, use as many as the OS will allow you.
+    outgoing-range: 8192
+
+    # permit Unbound to use this port number or port range for
+    # making outgoing queries, using an outgoing interface.
+    # outgoing-port-permit: 32768
+
+    # Maximum UDP response size (not applied to TCP response).
+    # Suggested values are 512 to 4096. Default is 1232. 65536 disables it.
+    # max-udp-size: 1232
+
+    # if yes, perform prefetching of almost expired message cache entries.
+    prefetch: yes
+
+    # if yes, perform key lookups adjacent to normal lookups.
+    prefetch-key: yes
+
+    # the amount of memory to use for the RRset cache.
+    # plain value in bytes or you can append k, m or G. default is "4Mb".
+    rrset-cache-size: 128m
+
+    # the number of slabs to use for the RRset cache. the number of slabs must
+    # be a power of 2. more slabs reduce lock contention, but fragment memory usage.
+    rrset-cache-slabs: 4
+
+    # Rotates RRSet order in response (the pseudo-random number is taken from
+    # the query ID, for speed and thread safety).
+    rrset-roundrobin: yes
+
+    # Serve expired responses from cache, with serve-expired-reply-ttl in
+    # the response, and then attempt to fetch the data afresh (actual
+    # resolution answer ends up in the cache later on).
+    serve-expired: yes
+
+    # Limit serving of expired responses to configured seconds after
+    # expiration. 0 disables the limit.
+    # serve-expired-ttl: 0
+    #
+    # Set the TTL of expired records to the serve-expired-ttl value after a
+    # failed attempt to retrieve the record from upstream. This makes sure
+    # that the expired records will be served as long as there are queries
+    # for it.
+    # serve-expired-ttl-reset: no
+    #
+    # TTL value to use when replying with expired data.
+    # serve-expired-reply-ttl: 30
+    #
+    # Time in milliseconds before replying to the client with expired data.
+    # This essentially enables the serve-stale behavior as specified in
+    # RFC 8767 that first tries to resolve before
+    # immediately responding with expired data.  0 disables this behavior.
+    # A recommended value is 1800.
+    # serve-expired-client-timeout: 0
+
+    # Return the original TTL as received from the upstream name server rather
+    # than the decrementing TTL as stored in the cache.  Enabling this feature
+    # does not impact cache expiry, it only changes the TTL Unbound embeds in
+    # responses to queries. Note that enabling this feature implicitly disables
+    # enforcement of the configured minimum and maximum TTL.
+    # serve-original-ttl: no
+
+    # buffer size for UDP port 53 incoming (SO_RCVBUF socket option).
+    # 0 is system default.  Use 4m to catch query spikes for busy servers.
+    # so-rcvbuf: 0
+
+    # buffer size for UDP port 53 outgoing (SO_SNDBUF socket option).
+    # 0 is system default.  Use 4m to handle spikes on very busy servers.
+    # so-sndbuf: 0
+
+    # use SO_REUSEPORT to distribute queries over threads.
+    # at extreme load it could be better to turn it off to distribute even.
+    so-reuseport: yes
+
+    # max memory to use for stream(tcp and tls) waiting result buffers.
+    # stream-wait-size: 4m
+
+remote-control:
+    control-enable: no

--- a/infrastructure/subsystems/networking-core/pihole/unbound/deployment.yaml
+++ b/infrastructure/subsystems/networking-core/pihole/unbound/deployment.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unbound
+  namespace: pihole
+  labels:
+    app.kubernetes.io/name: unbound
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: unbound
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: unbound
+    spec:
+      automountServiceAccountToken: false
+      containers:
+      - name: unbound
+        envFrom:
+        - configMapRef:
+            name: unbound-optional-config
+            optional: true
+        image: madnuttah/unbound:1.20.0-5@sha256:8d257bb2af8963aa4436a96fb6398fa47aea3fcf6ded212ca2fef796b5b29afb
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          tcpSocket:
+            port: 53
+          initialDelaySeconds: 15
+          periodSeconds: 15
+        ports:
+        - name: unbound-dns-tcp
+          containerPort: 53
+          protocol: TCP
+        - name: unbound-dns-udp
+          containerPort: 53
+          protocol: UDP
+        readinessProbe:
+          exec:
+            command: [drill, '-Q', '@127.0.0.1', cloudflare.com]
+          initialDelaySeconds: 15
+          periodSeconds: 60
+          timeoutSeconds: 10
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+        volumeMounts:
+        - name: unbound-config-volume
+          mountPath: /usr/local/unbound/unbound.conf
+          subPath: unbound.conf
+      dnsConfig:
+        nameservers:
+        - 127.0.0.1
+        - ${dns_fallback:=1.1.1.1}
+      dnsPolicy: None
+      hostname: unbound
+      volumes:
+      - name: unbound-config-volume
+        configMap:
+          name: unbound-config
+          optional: false
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: In
+                values:
+                - "true"
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists

--- a/infrastructure/subsystems/networking-core/pihole/unbound/kustomization.yaml
+++ b/infrastructure/subsystems/networking-core/pihole/unbound/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- deployment.yaml
+- service.yaml
+
+configMapGenerator:
+- name: unbound-config
+  namespace: pihole
+  files:
+  - conf.d/unbound.conf
+  options:
+    annotations:
+      kustomize.toolkit.fluxcd.io/substitute: disabled
+
+sortOptions:
+  order: fifo

--- a/infrastructure/subsystems/networking-core/pihole/unbound/service.yaml
+++ b/infrastructure/subsystems/networking-core/pihole/unbound/service.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: unbound
+  namespace: pihole
+  labels:
+    app.kubernetes.io/name: unbound
+spec:
+  selector:
+    app.kubernetes.io/name: unbound
+  ports:
+  - name: unbound-dns-tcp
+    port: 53
+    targetPort: unbound-dns-tcp
+    protocol: TCP
+  - name: unbound-dns-udp
+    port: 53
+    targetPort: unbound-dns-udp
+    protocol: UDP
+  type: ClusterIP

--- a/infrastructure/subsystems/networking-core/traefik/helm-release.yaml
+++ b/infrastructure/subsystems/networking-core/traefik/helm-release.yaml
@@ -1,0 +1,196 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: traefik-release
+  namespace: traefik
+spec:
+  chart:
+    spec:
+      chart: traefik
+      interval: 24h0m0s
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: traefik-repository
+        namespace: flux-system
+      version: 30.1.0
+  dependsOn:
+  - name: metallb-release
+    namespace: metallb-system
+  - name: cert-manager-release
+    namespace: cert-manager
+  install:
+    crds: CreateReplace
+    createNamespace: false
+    remediation:
+      retries: 3
+  interval: 15m0s
+  releaseName: traefik
+  targetNamespace: traefik
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      ignoreTestFailures: false
+      retries: 3
+      strategy: rollback
+  values:
+    logs:
+      general:
+        level: DEBUG
+      access:
+        enabled: true
+        format: json
+        filePath: /var/log/traefik/access.log
+
+    # these are the defaults set in helm chart for securityContext + podSecurityContext
+    # (see: https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml#L899)
+    # with the following adjustments
+    # - moving runAsGroup, runAsUser and runAsNonRoot (retaining their values) from
+    #   podSecurityContext to securityContext (of main traefik container)
+    # - this allows us to run the init-container as root, while ensuring the main
+    #   traefik container continues to run as non-root
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
+      readOnlyRootFilesystem: true
+      runAsGroup: 65532
+      runAsNonRoot: true
+      runAsUser: 65532
+    podSecurityContext: {}
+
+    deployment:
+      kind: DaemonSet
+      additionalVolumes:
+      - name: traefik-logs
+        hostPath:
+          path: /var/log/traefik
+          type: DirectoryOrCreate
+      initContainers:
+      - name: volume-permissions
+        image: busybox@sha256:c230832bd3b0be59a6c47ed64294f9ce71e91b327957920b6929a0caa8353140
+        command:
+        - "/bin/sh"
+        - "-c"
+        - "chown 65532:65532 /var/log/traefik"
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - CHOWN
+            drop:
+            - ALL
+          runAsNonRoot: false
+          runAsUser: 0
+          runAsGroup: 0
+        volumeMounts:
+        - mountPath: /var/log/traefik
+          name: traefik-logs
+    additionalVolumeMounts:
+    - mountPath: /var/log/traefik
+      name: traefik-logs
+
+    service:
+      spec:
+        externalTrafficPolicy: Local
+
+    # disable check new version + sending annonymous usage
+    globalArguments: []
+    additionalArguments: []
+
+    providers:
+      kubernetesCRD:
+        enabled: true
+        allowCrossNamespace: false
+        allowExternalNameServices: false
+      kubernetesIngress:
+        enabled: true
+        allowExternalNameServices: false
+        publishedService:
+          enabled: true
+
+    resources: {}
+    tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+
+    ingressRoute:
+      dashboard:
+        enabled: true
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: traefik.${domain_name}
+        matchRule: Host(`traefik.${domain_name}`)
+        entryPoints: ["websecure"]
+        middlewares: []
+        tls: {}
+    metrics:
+      prometheus:
+        addEntryPointsLabels: true
+        addRoutersLabels: true
+        addServicesLabels: true
+        service:
+          enabled: true
+        serviceMonitor:
+          enabled: true
+        prometheusRule:
+          enabled: false
+
+    tlsOptions:
+      default:
+        minVersion: VersionTLS12
+
+    tlsStore:
+      default:
+        defaultCertificate:
+          secretName: ${default_certificate:=selfsigned-tls-cert}
+
+    extraObjects:
+    # yamllint disable-line rule:indentation
+    - |
+      apiVersion: traefik.io/v1alpha1
+      kind: Middleware
+      metadata:
+        name: header-forwarded
+        namespace: traefik
+      spec:
+        headers:
+          customRequestHeaders:
+            X-Forwarded-Proto: "https"
+    # yamllint disable-line rule:indentation
+    - |
+      apiVersion: traefik.io/v1alpha1
+      kind: Middleware
+      metadata:
+        name: redirect
+        namespace: traefik
+      spec:
+        redirectScheme:
+          scheme: https
+          permanent: true
+    # yamllint disable-line rule:indentation
+    - |
+      apiVersion: traefik.io/v1alpha1
+      kind: ServersTransport
+      metadata:
+        name: insecure-skip-verify
+        namespace: traefik
+      spec:
+        insecureSkipVerify: true
+    # yamllint disable-line rule:indentation
+    - |
+      apiVersion: cert-manager.io/v1
+      kind: Certificate
+      metadata:
+        name: selfsigned-tls-cert
+        namespace: traefik
+      spec:
+        issuerRef:
+          name: selfsigned-issuer
+          kind: ClusterIssuer
+        dnsNames:
+        - '*.${domain_name}'
+        duration: 2160h # 90d
+        renewBefore: 1440h # 60d
+        secretName: selfsigned-tls-cert

--- a/infrastructure/subsystems/networking-core/traefik/kustomization.yaml
+++ b/infrastructure/subsystems/networking-core/traefik/kustomization.yaml
@@ -3,10 +3,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- cert-manager.yaml
-- external-dns.yaml
-- minio.yaml
-- pihole.yaml
+- helm-release.yaml
+- whoami-deployment.yaml
+- whoami-service.yaml
+- whoami-ingress.yaml
 
 sortOptions:
   order: fifo

--- a/infrastructure/subsystems/networking-core/traefik/whoami-deployment.yaml
+++ b/infrastructure/subsystems/networking-core/traefik/whoami-deployment.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: whoami
+  namespace: traefik
+  labels:
+    app.kubernetes.io/name: whoami
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: whoami
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: whoami
+    spec:
+      containers:
+      - name: whoami
+        image: traefik/whoami@sha256:43a68d10b9dfcfc3ffbfe4dd42100dc9aeaf29b3a5636c856337a5940f1b4f1c
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+          protocol: TCP
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: In
+                values:
+                - "true"
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists

--- a/infrastructure/subsystems/networking-core/traefik/whoami-ingress.yaml
+++ b/infrastructure/subsystems/networking-core/traefik/whoami-ingress.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: whoami-https
+  namespace: traefik
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: whoami.${domain_name}
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+spec:
+  # setting tls to [], so that default certficate will be assigned
+  tls: []
+  rules:
+  - host: whoami.${domain_name}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: whoami
+            port:
+              number: 80

--- a/infrastructure/subsystems/networking-core/traefik/whoami-service.yaml
+++ b/infrastructure/subsystems/networking-core/traefik/whoami-service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami
+  namespace: traefik
+  labels:
+    app.kubernetes.io/name: whoami
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: whoami
+  ports:
+  - name: whoami
+    port: 80
+    targetPort: 80
+    protocol: TCP

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -28,6 +28,12 @@
       "component": "infra-helm-repositories",
       "extra-label": "pr-type:release,subsystem:infra-helm-repositories"
     },
+    "infrastructure/subsystems/networking-core": {
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "component": "infra-networking-core",
+      "extra-label": "pr-type:release,subsystem:infra-networking-core"
+    },
     "infrastructure/subsystems/secrets-core": {
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
Add subsystem infra-networking-core providing the following infrastructure applications:
- [cert-manager](https://cert-manager.io/)
- [external-dns](https://github.com/kubernetes-sigs/external-dns)
- [metallb](https://metallb.universe.tf/)
- [pihole](https://pi-hole.net/)
   - w/ the following two upstreams:
      - [unbound](https://www.nlnetlabs.nl/projects/unbound/about/) 
      - [cloudflared DNS over HTTPS](https://developers.cloudflare.com/1.1.1.1/encryption/dns-over-https/)
- [traefik](https://traefik.io/)