### PR TITLE
feat(infra-kubernetes-extra): add cluster capabilty for intel gpu devices w/ intel-gpu-device-plugin

### DIFF
--- a/.github/workflows/test-infrastructure-kubernetes.yaml
+++ b/.github/workflows/test-infrastructure-kubernetes.yaml
@@ -29,6 +29,10 @@ jobs:
           kind: kustomization
           namespace: flux-system
           timeout: 3m
+        - name: infra-kubernetes-extra
+          kind: kustomization
+          namespace: flux-system
+          timeout: 3m
       # yamllint disable-line rule:indentation
       success_conditions: |-
         - resource: configmap/coredns-custom
@@ -58,6 +62,24 @@ jobs:
           namespace: kube-system
           for: condition=available
           timeout: 1m
+        - resource: helmrelease/intel-plugin-operator-release
+          namespace: intel-device-plugins
+          for: jsonpath={.metadata.creationTimestamp}
+          timeout: 1m
+        - resource: helmrelease/intel-gpu-plugin-release
+          namespace: intel-device-plugins
+          for: jsonpath={.metadata.creationTimestamp}
+          timeout: 1m
       git_url: https://github.com/${{ github.repository }}.git
       git_ref: ${{ github.head_ref || github.ref }}
       kind_cluster_config: kind-cluster-single-node.yaml
+      # yamllint disable-line rule:indentation
+      custom_commands: |-
+        - name: show-events1
+          command: 'kubectl get -n kube-system events --sort-by=.lastTimestamp'
+        - name: show-events2
+          command: 'kubectl get -n intel-device-plugins events --sort-by=.lastTimestamp'
+        - name: show-hr1
+          command: 'kubectl describe -n intel-device-plugins hr intel-plugin-operator-release'
+        - name: show-hr2
+          command: 'kubectl describe -n intel-device-plugins hr intel-gpu-plugin-release'

--- a/ci/test/infra-kubernetes/infra-kubernetes-extra.yaml
+++ b/ci/test/infra-kubernetes/infra-kubernetes-extra.yaml
@@ -18,3 +18,42 @@ spec:
     namespace: flux-system
   timeout: 2m0s
   wait: true
+  patches:
+  #############################################################################
+  # intel device plugins cannot be installed on github actions worker nodes
+  #############################################################################
+  # yamllint disable-line rule:indentation
+  - patch: |-
+      apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      metadata:
+        name: intel-plugin-operator-release
+        namespace: intel-device-plugins
+      spec:
+        install:
+          disableWait: true
+          retries: 0
+          ignoreTestFailures: true
+    target:
+      group: helm.toolkit.fluxcd.io
+      kind: HelmRelease
+      namespace: intel-device-plugins
+      name: intel-plugin-operator-release
+  # yamllint disable-line rule:indentation
+  - patch: |-
+      apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      metadata:
+        name: intel-gpu-plugin-release
+        namespace: intel-device-plugins
+      spec:
+        install:
+          disableWait: true
+          retries: 0
+          ignoreTestFailures: true
+        suspend: true
+    target:
+      group: helm.toolkit.fluxcd.io
+      kind: HelmRelease
+      namespace: intel-device-plugins
+      name: intel-gpu-plugin-release

--- a/ci/test/infra-kubernetes/infra-kubernetes-extra.yaml
+++ b/ci/test/infra-kubernetes/infra-kubernetes-extra.yaml
@@ -39,3 +39,23 @@ spec:
       group: helm.toolkit.fluxcd.io
       kind: HelmRelease
       namespace: intel-device-plugins
+      name: intel-plugin-operator-release
+  # yamllint disable-line rule:indentation
+  - patch: |-
+      apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      metadata:
+        name: intel-gpu-plugin-release
+        namespace: intel-device-plugins
+      spec:
+        install:
+          disableWait: true
+          remediation:
+            retries: 0
+            ignoreTestFailures: true
+        suspend: true
+    target:
+      group: helm.toolkit.fluxcd.io
+      kind: HelmRelease
+      namespace: intel-device-plugins
+      name: intel-gpu-plugin-release

--- a/ci/test/infra-kubernetes/infra-kubernetes-extra.yaml
+++ b/ci/test/infra-kubernetes/infra-kubernetes-extra.yaml
@@ -32,28 +32,10 @@ spec:
       spec:
         install:
           disableWait: true
-          retries: 0
-          ignoreTestFailures: true
+          remediation:
+            retries: 0
+            ignoreTestFailures: true
     target:
       group: helm.toolkit.fluxcd.io
       kind: HelmRelease
       namespace: intel-device-plugins
-      name: intel-plugin-operator-release
-  # yamllint disable-line rule:indentation
-  - patch: |-
-      apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      metadata:
-        name: intel-gpu-plugin-release
-        namespace: intel-device-plugins
-      spec:
-        install:
-          disableWait: true
-          retries: 0
-          ignoreTestFailures: true
-        suspend: true
-    target:
-      group: helm.toolkit.fluxcd.io
-      kind: HelmRelease
-      namespace: intel-device-plugins
-      name: intel-gpu-plugin-release

--- a/infrastructure/helm-repositories/intel.yaml
+++ b/infrastructure/helm-repositories/intel.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: intel-repository
+  namespace: flux-system
+spec:
+  interval: 15m0s
+  url: https://intel.github.io/helm-charts/

--- a/infrastructure/helm-repositories/kustomization.yaml
+++ b/infrastructure/helm-repositories/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - external-secrets.yaml
 - fairwinds.yaml
 - grafana.yaml
+- intel.yaml
 - longhorn.yaml
 - metallb.yaml
 - minio.yaml

--- a/infrastructure/subsystems/kubernetes-extra/intel-device-plugins/helm-release-intel-gpu-plugin.yaml
+++ b/infrastructure/subsystems/kubernetes-extra/intel-device-plugins/helm-release-intel-gpu-plugin.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: intel-gpu-plugin-release
+  namespace: intel-device-plugins
+spec:
+  chart:
+    spec:
+      chart: intel-device-plugins-gpu
+      interval: 24h0m0s
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: intel-repository
+        namespace: flux-system
+      version: 0.30.0
+  dependsOn:
+  - name: intel-plugin-operator-release
+    namespace: intel-device-plugins
+  install:
+    crds: CreateReplace
+    createNamespace: false
+    remediation:
+      retries: 3
+  interval: 15m0s
+  releaseName: intel-gpu-plugin
+  targetNamespace: intel-device-plugins
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      ignoreTestFailures: false
+      retries: 3
+      strategy: rollback
+
+  values:
+    # name given to the gpu plugin CRD will be a suffix for the gpu plugin daemon set and pods
+    name: gpu-device
+
+    # see crd for docs
+    sharedDevNum: ${gpu_shared_across_max_pods:=1}
+    logLevel: 2
+    resourceManager: false
+    enableMonitoring: true
+
+    tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+
+    nodeFeatureRule: true

--- a/infrastructure/subsystems/kubernetes-extra/intel-device-plugins/helm-release-intel-plugin-operator.yaml
+++ b/infrastructure/subsystems/kubernetes-extra/intel-device-plugins/helm-release-intel-plugin-operator.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: intel-plugin-operator-release
+  namespace: intel-device-plugins
+spec:
+  chart:
+    spec:
+      chart: intel-device-plugins-operator
+      interval: 24h0m0s
+      reconcileStrategy: ChartVersion
+      sourceRef:
+        kind: HelmRepository
+        name: intel-repository
+        namespace: flux-system
+      version: 0.30.0
+  dependsOn:
+  - name: node-feature-discovery-release
+    namespace: kube-system
+  install:
+    crds: CreateReplace
+    createNamespace: false
+    remediation:
+      retries: 3
+  interval: 15m0s
+  releaseName: intel-plugin-operator
+  targetNamespace: intel-device-plugins
+  upgrade:
+    crds: CreateReplace
+    cleanupOnFail: true
+    remediation:
+      ignoreTestFailures: false
+      retries: 3
+      strategy: rollback
+  values:
+    nodeSelector:
+      kubernetes.io/arch: amd64
+      feature.node.kubernetes.io/cpu-model.vendor_id: Intel
+  postRenderers:
+  - kustomize:
+      patches:
+      - target:
+          kind: Deployment
+        # yamllint disable-line rule:indentation
+        patch: |-
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: irrelevant
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                    - weight: 1
+                      preference:
+                        matchExpressions:
+                        - key: node-role.kubernetes.io/control-plane
+                          operator: In
+                          values:
+                          - "true"
+                tolerations:
+                - key: node-role.kubernetes.io/control-plane
+                  operator: Exists

--- a/infrastructure/subsystems/kubernetes-extra/intel-device-plugins/kustomization.yaml
+++ b/infrastructure/subsystems/kubernetes-extra/intel-device-plugins/kustomization.yaml
@@ -3,10 +3,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- namespace.yaml
-- node-feature-discovery/
-- vertical-pod-autoscaler/
-- intel-device-plugins/
+- helm-release-intel-plugin-operator.yaml
+- helm-release-intel-gpu-plugin.yaml
 
 sortOptions:
   order: fifo

--- a/infrastructure/subsystems/kubernetes-extra/namespace.yaml
+++ b/infrastructure/subsystems/kubernetes-extra/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: intel-device-plugins
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    kustomize.toolkit.fluxcd.io/ssa: merge
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/infrastructure/subsystems/kubernetes-extra/node-feature-discovery/helm-release.yaml
+++ b/infrastructure/subsystems/kubernetes-extra/node-feature-discovery/helm-release.yaml
@@ -57,6 +57,9 @@ spec:
       config:
         sources:
           usb:
+            # yamllint disable-line rule:line-length
+            # see: https://kubernetes-sigs.github.io/node-feature-discovery/v0.16/reference/worker-configuration-reference#sourcesusbdeviceclasswhitelist
+            # see: https://www.usb.org/defined-class-codes
             deviceClassWhitelist: ["02", "03", "08", "0e", "ef", "fe", "ff"]
             deviceLabelFields: ["class", "vendor", "device"]
       # resources:


### PR DESCRIPTION
Add cluster capability for Intel GPUs to infra-kubernetes-extra subsystem:
  1. Install Intel Device Plugins operator which will expose discovered Intel devices as NodeFeature (from Node Feature Discovery)
  2. Install and configure Intel GPU device plugin as an Intel device capability to be discovered by Intel Device Plugins operator.