### PR TITLE
ci(infra-storage-core): enable upgrading minio image via renovate

### DIFF
--- a/infrastructure/subsystems/storage-core/minio/helm-release.yaml
+++ b/infrastructure/subsystems/storage-core/minio/helm-release.yaml
@@ -58,6 +58,9 @@ spec:
     # -------------------------------------------- minio configuration --------------------------------------------
     mode: standalone
     ignoreChartChecksums: true
+    image:
+      # renovate: datasource=github-releases depName=minio/minio versioning=loose
+      tag: "RELEASE.2024-04-18T19-09-19Z"
     existingSecret: minio-admin-credentials
     persistence:
       enabled: true

--- a/infrastructure/subsystems/storage-core/minio/helm-release.yaml
+++ b/infrastructure/subsystems/storage-core/minio/helm-release.yaml
@@ -59,7 +59,8 @@ spec:
     mode: standalone
     ignoreChartChecksums: true
     image:
-      # renovate: datasource=github-releases depName=minio/minio versioning=loose
+      # yamllint disable-line rule:line-length
+      # renovate: datasource=github-releases depName=minio/minio versioning=regex:^RELEASE\\.(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})
       tag: "RELEASE.2024-04-18T19-09-19Z"
     existingSecret: minio-admin-credentials
     persistence:


### PR DESCRIPTION
As minio helm chart version upgrades rarely upgrade the image version.