### PR TITLE
ci: add markdown linting to pre-commit and github actions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -97,7 +97,7 @@ jobs:
   markdown:
     needs: [detect-changes]
     if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.markdown_any_changed == 'true' }}
-    uses: ppat/github-workflows/.github/workflows/lint-markdown.yaml@markdownlint
+    uses: ppat/github-workflows/.github/workflows/lint-markdown.yaml@main
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name == 'workflow_dispatch' && 'ALL' || needs.detect-changes.outputs.markdown_all_changed_files }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,6 +21,8 @@ jobs:
       shellscripts_all_changed_files: ${{ steps.changed-files-yaml.outputs.shellscripts_all_changed_files}}
       yaml_any_changed: ${{ steps.changed-files-yaml.outputs.yaml_any_changed }}
       yaml_all_changed_files: ${{ steps.changed-files-yaml.outputs.yaml_all_changed_files}}
+      markdown_any_changed: ${{ steps.changed-files-yaml.outputs.markdown_any_changed }}
+      markdown_all_changed_files: ${{ steps.changed-files-yaml.outputs.markdown_all_changed_files}}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
@@ -43,6 +45,8 @@ jobs:
           - '**.sh'
           yaml:
           - '**.yaml'
+          markdown:
+          - '**.md'
 
   commit-messages:
     if: ${{ github.event_name == 'pull_request' }}
@@ -89,3 +93,29 @@ jobs:
     with:
       git_ref: ${{ github.head_ref || github.ref }}
       files: ${{ github.event_name == 'workflow_dispatch' && 'ALL' || needs.detect-changes.outputs.yaml_all_changed_files }}
+
+  markdown:
+    needs: [detect-changes]
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.markdown_any_changed == 'true' }}
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
+      with:
+        node-version: 'lts/*'
+        cache: 'npm'
+
+    - name: Install markdownlint-cli2
+      run: npm install -g markdownlint-cli2
+
+    - name: Run markdownlint
+      # yamllint disable-line rule:indentation
+      run: |
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          markdownlint-cli2 "**/*.md"
+        else
+          markdownlint-cli2 ${{ needs.detect-changes.outputs.markdown_all_changed_files }}
+        fi

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -97,24 +97,7 @@ jobs:
   markdown:
     needs: [detect-changes]
     if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.markdown_any_changed == 'true' }}
-    runs-on: ubuntu-24.04
-    steps:
-    - name: Checkout
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-
-    - name: Setup Node.js
-      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
-      with:
-        cache: 'npm'
-
-    - name: Install markdownlint-cli2
-      run: npm install -g markdownlint-cli2
-
-    - name: Run markdownlint
-      # yamllint disable-line rule:indentation
-      run: |
-        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-          markdownlint-cli2 "**/*.md"
-        else
-          markdownlint-cli2 ${{ needs.detect-changes.outputs.markdown_all_changed_files }}
-        fi
+    uses: ppat/github-workflows/.github/workflows/lint-markdown.yaml@markdownlint
+    with:
+      git_ref: ${{ github.head_ref || github.ref }}
+      files: ${{ github.event_name == 'workflow_dispatch' && 'ALL' || needs.detect-changes.outputs.markdown_all_changed_files }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -105,7 +105,6 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
       with:
-        node-version: 'lts/*'
         cache: 'npm'
 
     - name: Install markdownlint-cli2

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,34 @@
+---
+# Default state for all rules
+default: true
+
+# Files to ignore
+ignores:
+- "**/CHANGELOG.md"
+
+# MD013/line-length - Line length
+MD013: false
+
+# MD024/no-duplicate-heading - Multiple headings with the same content
+MD024:
+  # Allow different nesting levels
+  allow_different_nesting: true
+
+# MD033/no-inline-html - Inline HTML
+MD033:
+  # Allow specific HTML elements
+  allowed_elements:
+  - br
+  - details
+  - summary
+
+# MD041/first-line-heading - First line in a file should be a heading
+MD041: false
+
+# MD046/code-block-style - Code block style
+MD046:
+  style: fenced
+
+# MD048/code-fence-style - Code fence style
+MD048:
+  style: backtick

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,10 @@
 ---
 repos:
+- repo: https://github.com/DavidAnson/markdownlint-cli2
+  rev: v0.17.2
+  hooks:
+  - id: markdownlint-cli2
+    args: ["--fix", "--config", ".markdownlint.yaml"]
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
   hooks:

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,6 +1,7 @@
 # Active Context
 
 ## Current State
+
 - Repository providing reusable Kubernetes modules for GitOps-based deployment
 - Modules designed for consumption by separate cluster configuration repositories
 - Well-established module types (Infrastructure, Application, Component)
@@ -8,25 +9,29 @@
 - Testing currently implemented through GitHub Actions workflows
 
 ## Active Initiatives
+
 - Documentation establishment
-  * Individual module documentation
-  * Repository-wide documentation
-  * Usage patterns and guidelines
+  - Individual module documentation
+  - Repository-wide documentation
+  - Usage patterns and guidelines
 - Testing framework migration from GitHub Actions to kyverno/chainsaw
 
 ## Backlog Items
+
 - Migration from flannel + metallb to cillium for CNI and load balancing
 - Implementation of sensible default alerts across modules
 - Development of comprehensive backup strategy
 - Future security controls through kyverno
 
 ## Key Metrics
+
 - Module deployment success rates
 - Test coverage and validation metrics
 - Documentation completeness
 - Module reusability across clusters
 
 ## Current Focus Areas
+
 1. Documentation
    - Individual module documentation
    - Repository-wide documentation standards
@@ -40,6 +45,7 @@
    - Enhance kubernetes context awareness
 
 ## Recent Changes
+
 - Core/extra pattern implementation across various modules
 - Comprehensive storage solutions (block, object, NFS)
 - Module structure standardization

--- a/memory-bank/architectureOverview.md
+++ b/memory-bank/architectureOverview.md
@@ -1,52 +1,58 @@
 # Architecture Overview
 
 ## Repository Purpose
+
 This repository serves as a collection of Kubernetes modules that can be composed to build complete cluster configurations. The actual cluster deployments and environment-specific configurations are maintained in separate repositories that reference and use these modules.
 
 ## Module Types
 
 ### Infrastructure Modules
+
 - Provide core cluster services and capabilities
 - Focus on platform capabilities and operational needs
 - Located in `/infrastructure` directory
 - Examples:
-  * security-core/extra: Certificate and secret management
-  * storage-core: Block, object, and NFS storage
-  * networking-core/extra: CNI and load balancing
-  * kubernetes-core/extra: Core kubernetes enhancements
-  * clusterops-core/extra: Operational capabilities
-  * observability-core: Monitoring and metrics
+  - security-core/extra: Certificate and secret management
+  - storage-core: Block, object, and NFS storage
+  - networking-core/extra: CNI and load balancing
+  - kubernetes-core/extra: Core kubernetes enhancements
+  - clusterops-core/extra: Operational capabilities
+  - observability-core: Monitoring and metrics
 
 ### Application Modules
+
 - Deliver end-user functionality
 - Depend on infrastructure module capabilities
 - Located in `/apps` directory
 - Examples:
-  * Media services
-  * Home automation
-  * Development tools
+  - Media services
+  - Home automation
+  - Development tools
 
 ### Component Modules
+
 - Provide cross-cutting configuration and capabilities
 - Apply consistent configuration across multiple modules
 - Located in `/components` directory
 - Examples:
-  * SSO configuration
-  * Backup components
-  * Cross-cutting patches
+  - SSO configuration
+  - Backup components
+  - Cross-cutting patches
 
 ## Core/Extra Pattern
+
 - Used to break circular dependencies across various module types
 - Separates essential services (core) from additional features (extra)
 - Currently implemented in:
-  * Networking modules
-  * Observability modules
-  * Kubernetes modules
-  * ClusterOps modules
-  * Security modules
+  - Networking modules
+  - Observability modules
+  - Kubernetes modules
+  - ClusterOps modules
+  - Security modules
 - Enables gradual deployment of complex systems
 
 ## Storage Capabilities
+
 1. Block Storage
    - Provides persistent block storage volumes
    - Used for stateful applications
@@ -60,6 +66,7 @@ This repository serves as a collection of Kubernetes modules that can be compose
    - Enables integration with existing storage systems
 
 ## Configuration Methods
+
 1. Kustomize Patches
    - Primary method for module-specific parameterization
    - Applied through Flux Kustomization
@@ -76,7 +83,9 @@ This repository serves as a collection of Kubernetes modules that can be compose
    - Enables flexible configuration composition
 
 ## Testing Framework
+
 Current:
+
 - GitHub Actions workflows
 - Series of steps (preparation, action, validation)
 - Each step implemented via shell scripts
@@ -84,6 +93,7 @@ Current:
 - Manual kubernetes operation specification
 
 Planned Migration:
+
 - Moving to kyverno/chainsaw framework
 - Will enable local testing during development
 - Provides clear kubernetes context awareness
@@ -91,6 +101,7 @@ Planned Migration:
 - Can run both locally and in CI
 
 ## Monitoring & Metrics
+
 1. Metrics Collection
    - Comprehensive metrics collection via Prometheus
    - Service monitors for various components
@@ -102,6 +113,7 @@ Planned Migration:
    - Planned enhancement for sensible default alerts
 
 ## Module Usage
+
 1. Module Definition
    - Modules defined in this repository
    - Self-contained units of functionality
@@ -115,6 +127,7 @@ Planned Migration:
    - Enables flexibility across different environments
 
 ## Documentation Status
+
 1. Current Priority
    - Individual module documentation
    - Repository-wide documentation

--- a/memory-bank/decisionLog.md
+++ b/memory-bank/decisionLog.md
@@ -3,14 +3,15 @@
 ## Interaction Protocol Decisions
 
 ### IP-1: Error Handling in AI Assistant Interactions
+
 - **Decision**: Implement "3-strikes" rule for error handling in AI assistant operations
 - **Context**: Need for efficient problem resolution in AI assistant interactions with user
 - **Consequences**:
   - After 3 failed attempts at any operation (local commands, MCP usage, LLM API):
-    * AI assistant will stop attempting further retries
-    * Prompt user whether to continue trying different approaches
-    * Ask for help if stuck
-    * Avoid endless retry loops
+    - AI assistant will stop attempting further retries
+    - Prompt user whether to continue trying different approaches
+    - Ask for help if stuck
+    - Avoid endless retry loops
   - More efficient problem resolution
   - Better user collaboration
   - Clear escalation path
@@ -19,6 +20,7 @@
 ## Architectural Decisions
 
 ### AD-1: Repository Purpose and Scope
+
 - **Decision**: Repository to provide reusable modules rather than direct cluster deployments
 - **Context**: Need for maintainable, reusable infrastructure components
 - **Consequences**:
@@ -28,6 +30,7 @@
   - Better reusability and maintenance
 
 ### AD-2: Core/Extra Pattern Implementation
+
 - **Decision**: Implement core/extra pattern across multiple infrastructure modules
 - **Context**: Need to handle circular dependencies and complex deployment sequences
 - **Consequences**:
@@ -37,6 +40,7 @@
   - More maintainable module structure
 
 ### AD-3: Storage Solution Architecture
+
 - **Decision**: Implement comprehensive storage solutions (block, object, NFS)
 - **Context**: Need for diverse storage capabilities in kubernetes clusters
 - **Consequences**:
@@ -46,6 +50,7 @@
   - More complex configuration requirements
 
 ### AD-4: Testing Framework Migration
+
 - **Decision**: Migrate from GitHub Actions shell scripts to kyverno/chainsaw
 - **Context**: Current testing limited to CI environment and lacks local capability
 - **Consequences**:
@@ -57,6 +62,7 @@
 ## Implementation Decisions
 
 ### ID-1: Module Structure
+
 - **Decision**: Strict separation of module definition from usage
 - **Context**: Need for reusable, maintainable modules
 - **Consequences**:
@@ -66,6 +72,7 @@
   - Additional integration effort
 
 ### ID-2: Configuration Methods
+
 - **Decision**: Support multiple configuration methods (Kustomize, FluxCD, Components)
 - **Context**: Different configuration needs require different approaches
 - **Consequences**:
@@ -75,6 +82,7 @@
   - More complex configuration management
 
 ### ID-3: Documentation Priority
+
 - **Decision**: Prioritize comprehensive documentation
 - **Context**: Need for clear module and repository documentation
 - **Consequences**:
@@ -86,6 +94,7 @@
 ## Future Considerations
 
 ### FC-1: Testing Enhancement
+
 - **Status**: In Progress
 - **Context**: Moving to kyverno/chainsaw framework
 - **Options**:
@@ -95,6 +104,7 @@
   - Local testing support
 
 ### FC-2: Infrastructure Evolution
+
 - **Status**: Planned
 - **Context**: Various infrastructure improvements needed
 - **Options**:

--- a/memory-bank/implementationReviewFindings.md
+++ b/memory-bank/implementationReviewFindings.md
@@ -3,6 +3,7 @@
 ## Module Types and Organization
 
 ### Infrastructure Modules
+
 - **Strengths**:
   - Clear core/extra separation across multiple modules
   - Well-defined dependencies
@@ -14,6 +15,7 @@
   - Backup strategy needs development
 
 ### Application Modules
+
 - **Strengths**:
   - Consistent deployment structure
   - Good use of HelmReleases
@@ -24,6 +26,7 @@
   - Consider canary deployment patterns
 
 ### Component Modules
+
 - **Strengths**:
   - Consistent configuration patterns
   - Good integration guidelines
@@ -36,11 +39,12 @@
 ## Infrastructure Implementation Details
 
 ### Storage Implementation
+
 - **Strengths**:
   - Comprehensive storage solutions:
-    * Block storage for persistent volumes
-    * Object storage capabilities
-    * External NFS volume mount support
+    - Block storage for persistent volumes
+    - Object storage capabilities
+    - External NFS volume mount support
   - Clear dependency management
 - **Areas for Improvement**:
   - Document storage scaling guidelines
@@ -48,6 +52,7 @@
   - Consider storage optimization strategies
 
 ### Monitoring Implementation
+
 - **Strengths**:
   - Comprehensive metrics collection
   - Good integration with other modules
@@ -58,6 +63,7 @@
   - Need better alert documentation and standards
 
 ### Security Implementation
+
 - **Strengths**:
   - Certificate management via cert-manager
   - Secret management via external-secrets
@@ -70,6 +76,7 @@
 ## Testing Implementation
 
 ### Current GitHub Actions Workflow
+
 - **Strengths**:
   - Automated testing in CI
   - Structured workflow steps
@@ -80,6 +87,7 @@
   - Lack of local testing capability
 
 ### Planned Testing Framework
+
 - **Migration to kyverno/chainsaw**:
   - Will enable local testing during development
   - Provides clear kubernetes context awareness
@@ -87,6 +95,7 @@
   - Can run both locally and in CI
 
 ### Resource Validation
+
 - **Strengths**:
   - Effective use of kubeconform
   - Good CRD validation
@@ -99,6 +108,7 @@
 ## Version Management
 
 ### Automated Updates
+
 - **Strengths**:
   - Effective use of Renovate
   - Clear update policies
@@ -109,6 +119,7 @@
   - Enhance update notification system
 
 ### Release Process
+
 - **Strengths**:
   - Automated changelog generation
   - Clear versioning strategy
@@ -121,6 +132,7 @@
 ## Priority Improvements
 
 ### High Priority
+
 1. Documentation
    - Individual module documentation
    - Repository-wide documentation
@@ -134,6 +146,7 @@
    - Enhance kubernetes context awareness
 
 ### Backlog Items
+
 1. Infrastructure
    - Migration to cillium for CNI and load balancing
    - Implementation of default alerts

--- a/memory-bank/productContext.md
+++ b/memory-bank/productContext.md
@@ -1,11 +1,13 @@
 # Product Context
 
 ## Project Purpose
+
 This repository provides a collection of reusable Kubernetes modules that can be composed to build complete cluster configurations. These modules are consumed by separate cluster configuration repositories where environment-specific settings are applied. The project enables consistent, maintainable, and automated infrastructure deployment through GitOps principles.
 
 ## Goals
 
 ### Primary Goals
+
 1. Module Reusability
    - Self-contained module definitions
    - Clear module interfaces
@@ -25,6 +27,7 @@ This repository provides a collection of reusable Kubernetes modules that can be
    - Reliable operations
 
 ### Success Metrics
+
 1. Module Metrics
    - Module reuse across clusters
    - Configuration flexibility
@@ -46,6 +49,7 @@ This repository provides a collection of reusable Kubernetes modules that can be
 ## Requirements
 
 ### Functional Requirements
+
 1. Module Implementation
    - Self-contained functionality
    - Clear dependencies
@@ -65,6 +69,7 @@ This repository provides a collection of reusable Kubernetes modules that can be
    - Deployment automation
 
 ### Non-Functional Requirements
+
 1. Reusability
    - Module independence
    - Clear interfaces
@@ -86,6 +91,7 @@ This repository provides a collection of reusable Kubernetes modules that can be
 ## Constraints
 
 ### Technical Constraints
+
 1. Module Design
    - Kubernetes platform
    - FluxCD for GitOps
@@ -105,6 +111,7 @@ This repository provides a collection of reusable Kubernetes modules that can be
    - Version control
 
 ### Operational Constraints
+
 1. Module Updates
    - Version management
    - Dependency tracking
@@ -120,6 +127,7 @@ This repository provides a collection of reusable Kubernetes modules that can be
 ## Future Considerations
 
 ### Short-term Roadmap
+
 1. Documentation Enhancement
    - Module usage documentation
    - Repository-wide standards
@@ -133,6 +141,7 @@ This repository provides a collection of reusable Kubernetes modules that can be
    - Validation enhancement
 
 ### Backlog Items
+
 1. Infrastructure Evolution
    - Migration to cillium for CNI and load balancing
    - Implementation of default alerts

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -3,34 +3,37 @@
 ## Current Status
 
 ### Documentation (High Priority)
+
 - [ ] Individual module documentation
-  * Module capabilities
-  * Configuration options
-  * Integration patterns
-  * Usage examples
+  - Module capabilities
+  - Configuration options
+  - Integration patterns
+  - Usage examples
 - [ ] Repository-wide documentation
-  * Architecture overview
-  * Module organization
-  * Development guidelines
-  * Testing procedures
+  - Architecture overview
+  - Module organization
+  - Development guidelines
+  - Testing procedures
 - [ ] Usage patterns and guidelines
-  * Module composition
-  * Configuration methods
-  * Integration approaches
-  * Best practices
+  - Module composition
+  - Configuration methods
+  - Integration approaches
+  - Best practices
 
 ### Testing Framework (High Priority)
+
 - [ ] Migration to kyverno/chainsaw
-  * Framework setup
-  * Local testing implementation
-  * CI integration
-  * Documentation update
+  - Framework setup
+  - Local testing implementation
+  - CI integration
+  - Documentation update
 - [ ] Current GitHub Actions workflows
-  * Structured workflow steps
-  * Shell script based operations
-  * Limited to CI environment
+  - Structured workflow steps
+  - Shell script based operations
+  - Limited to CI environment
 
 ### Infrastructure Modules
+
 - [x] Core module structure established
 - [x] Core/extra pattern implemented across multiple modules
 - [x] FluxCD integration complete
@@ -39,12 +42,14 @@
 - [x] Certificate and secret management
 
 ### Application Modules
+
 - [x] Basic deployment patterns
 - [x] Configuration management
 - [x] Service integration
 - [x] Module independence
 
 ### Component Modules
+
 - [x] Cross-cutting configuration structure
 - [x] Basic backup functionality
 - [x] Configuration flexibility
@@ -52,12 +57,14 @@
 ## Backlog Items
 
 ### Infrastructure Evolution
+
 - [ ] Migration from flannel + metallb to cillium
 - [ ] Default alert configurations
 - [ ] Comprehensive backup strategy
 - [ ] Security controls through kyverno
 
 ### Testing Improvements
+
 - [ ] Local testing capability
 - [ ] Comprehensive test coverage
 - [ ] Kubernetes-aware testing
@@ -66,6 +73,7 @@
 ## Milestones
 
 ### Current Focus
+
 1. Documentation Enhancement
    - [ ] Module documentation
    - [ ] Repository documentation
@@ -79,6 +87,7 @@
    - [ ] Documentation
 
 ### Completed
+
 1. Module Structure
    - [x] Infrastructure modules
    - [x] Application modules
@@ -99,6 +108,7 @@
 ## Blockers & Challenges
 
 ### Current Blockers
+
 1. Documentation
    - Comprehensive documentation needed
    - Usage patterns to be documented
@@ -110,6 +120,7 @@
    - Migration complexity
 
 ### Resolved Challenges
+
 1. Module Organization
    - Core/extra pattern implementation
    - Dependency management
@@ -123,6 +134,7 @@
 ## Next Steps
 
 ### Immediate Actions
+
 1. Documentation Development
    - Create module documentation
    - Develop repository guidelines
@@ -136,6 +148,7 @@
    - Create documentation
 
 ### Future Plans
+
 1. Infrastructure Evolution
    - CNI and load balancing migration
    - Alert configuration


### PR DESCRIPTION
- Add markdownlint-cli2 to pre-commit hooks
- Create markdownlint configuration with documentation-focused rules
- Update GitHub Actions to run markdown linting in CI