### PR TITLE
ci: explicitly set permissions (and environment if applicable) for github actions workflow job

### DIFF
--- a/.github/workflows/diff-changes.yaml
+++ b/.github/workflows/diff-changes.yaml
@@ -15,13 +15,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   diff:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-    permissions:
-      contents: read
-      pull-requests: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   detect-changes:
     outputs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,11 +16,14 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
+permissions: {}
+
 jobs:
   release:
     name: release
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    environment: release
     steps:
     - name: Generate github app token for renovate
       uses: actions/create-github-app-token@0d564482f06ca65fa9e77e2510873638c82206f2 # v1

--- a/.github/workflows/test-apps-ai.yaml
+++ b/.github/workflows/test-apps-ai.yaml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-apps-ai:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test-apps-bitwarden.yaml
+++ b/.github/workflows/test-apps-bitwarden.yaml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-apps-bitwarden:
     uses: ./.github/workflows/test-kubernetes-resources-workflow.yaml

--- a/.github/workflows/test-apps-coder.yaml
+++ b/.github/workflows/test-apps-coder.yaml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-apps-coder:
     uses: ./.github/workflows/test-kubernetes-resources-workflow.yaml

--- a/.github/workflows/test-apps-downloaders.yaml
+++ b/.github/workflows/test-apps-downloaders.yaml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-apps-downloaders:
     uses: ./.github/workflows/test-kubernetes-resources-workflow.yaml

--- a/.github/workflows/test-apps-harbor.yaml
+++ b/.github/workflows/test-apps-harbor.yaml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-apps-harbor:
     uses: ./.github/workflows/test-kubernetes-resources-workflow.yaml

--- a/.github/workflows/test-apps-home-automation.yaml
+++ b/.github/workflows/test-apps-home-automation.yaml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-apps-home-automation:
     uses: ./.github/workflows/test-kubernetes-resources-workflow.yaml

--- a/.github/workflows/test-apps-media.yaml
+++ b/.github/workflows/test-apps-media.yaml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-apps-media:
     uses: ./.github/workflows/test-kubernetes-resources-workflow.yaml

--- a/.github/workflows/test-infrastructure-clusterops.yaml
+++ b/.github/workflows/test-infrastructure-clusterops.yaml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-infrastructure-clusterops:
     uses: ./.github/workflows/test-kubernetes-resources-workflow.yaml

--- a/.github/workflows/test-infrastructure-database.yaml
+++ b/.github/workflows/test-infrastructure-database.yaml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-infrastructure-database:
     uses: ./.github/workflows/test-kubernetes-resources-workflow.yaml

--- a/.github/workflows/test-infrastructure-kubernetes.yaml
+++ b/.github/workflows/test-infrastructure-kubernetes.yaml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-infrastructure-kubernetes:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test-infrastructure-networking.yaml
+++ b/.github/workflows/test-infrastructure-networking.yaml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-infrastructure-networking:
     uses: ./.github/workflows/test-kubernetes-resources-workflow.yaml

--- a/.github/workflows/test-infrastructure-observability.yaml
+++ b/.github/workflows/test-infrastructure-observability.yaml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-infrastructure-observability:
     uses: ./.github/workflows/test-kubernetes-resources-workflow.yaml

--- a/.github/workflows/test-infrastructure-security.yaml
+++ b/.github/workflows/test-infrastructure-security.yaml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-infrastructure-security:
     uses: ./.github/workflows/test-kubernetes-resources-workflow.yaml

--- a/.github/workflows/test-infrastructure-storage.yaml
+++ b/.github/workflows/test-infrastructure-storage.yaml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-infrastructure-storage:
     uses: ./.github/workflows/test-kubernetes-resources-workflow.yaml

--- a/.github/workflows/validate-kubernetes-manifests.yaml
+++ b/.github/workflows/validate-kubernetes-manifests.yaml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   FLUX_SCHEMA_DIR: /tmp/flux-crd-schemas/master-standalone-strict
 jobs:


### PR DESCRIPTION
- Limit the capabilities of default GITHUB_TOKEN
- Move all repository wide secrets to environments and set environments explicitly on jobs that need those secrets