### PR TITLE
fix(github-actions): fix CVE-2025-30066 and pre-emptive security measures

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Determine what files types have changed
       id: changed-files-yaml
-      uses: tj-actions/changed-files@dcc7a0cba800f454d79fff4b993e8c3555bcc0a8 # v45
+      uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46
       with:
         files_yaml: |
           actions:


### PR DESCRIPTION
- Fix CVE-2025-30066 by upgrading to tj-actions/changed-files to v46
- Rotate all secrets used in Github Actions
- Previous [PR](https://github.com/ppat/homelab-ops-kubernetes-apps/pull/948) set up pre-emptive measures to limit the blast radius of future vulnerabilities in github actions
  - explicitly set permission for default GITHUB_TOKEN to limit its capabilities to only whats needed
  - Move repository wide secrets to environments where possible and set environments explicitly on jobs that need those secrets