### PR TITLE
ci(renovate): various updates to renovate rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,46 +10,25 @@
         "# renovate: datasource=(?<datasource>[a-z-.]+?)\\s+depName=(?<depName>[a-zA-Z0-9-/]+?)(\\s+repository=(?<registryUrl>[^\\s]+?))?(\\s+versioning=(?<versioning>[^\\s]+?))?(\\s+extractVersion=(?<extractVersion>[^\\s]+?))?\\s*\\n.+[\\:\\=]\\s?\"v?(?<currentValue>[^\\s]+)\""
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/^.github/workflows/.+\\.yaml$/"
-      ],
-      "matchStrings": [
-        "# renovate-kind-image: datasource=(?<datasource>[a-z-.]+?)(\\s+repository=(?<registryUrl>[^\\s]+?))?(\\s+versioning=(?<versioning>[^\\s]+?))?\\s*\\n.+[\\:\\=]\\s?\"(?<depName>[^:]+)\\:(?<currentValue>[^\\s@]+)(@(?<currentDigest>sha256:[0-9a-f]*))?\""
-      ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/).+\\.ya?ml$/"
-      ],
-      "matchStrings": [
-        "# renovate-gh-release-asset: datasource=(?<datasource>[a-z-.]+?)\\s+depName=(?<depName>[a-zA-Z0-9-/]+?)(\\s+repository=(?<registryUrl>[^\\s]+?))?(\\s+versioning=(?<versioning>[^\\s]+?))?(\\s+extractVersion=(?<extractVersion>[^\\s]+?))?\\s*\\n.+github\\.com(\\.)?\\/(.+)\\/releases\\/download\\/v(?<currentValue>[^\\/]+)\\/"
-      ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/).+\\.ya?ml$/"
-      ],
-      "matchStrings": [
-        "# renovate-gh-raw-url: datasource=(?<datasource>[a-z-.]+?)\\s+depName=(?<depName>[a-zA-Z0-9-/]+?)(\\s+repository=(?<registryUrl>[^\\s]+?))?(\\s+versioning=(?<versioning>[^\\s]+?))?(\\s+extractVersion=(?<extractVersion>[^\\s]+?))?\\s*\n.+raw\\.githubusercontent\\.com(\\.)?\\/(.+)\\/v(?<currentValue>[^\\/]+)\\/"
-      ],
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }
   ],
+  "configMigration": true,
+  "dependencyDashboard": true,
   "extends": [
-    "config:best-practices",
-    "group:linters",
+    ":ignoreModulesAndTests",
+    "abandonments:recommended",
+    "docker:pinDigests",
+    "helpers:pinGitHubActionDigests",
+    "mergeConfidence:age-confidence-badges",
     "mergeConfidence:all-badges",
+    "security:openssf-scorecard",
+    "workarounds:bitnamiDockerImageVersioning",
+    "workarounds:k3sKubernetesVersioning",
     "github>ppat/renovate-presets#v0.0.2",
     "github>ppat/renovate-presets:dev-tools#v0.0.2",
     "github>ppat/renovate-presets:github-actions#v0.0.2",
     "github>ppat/renovate-presets:kubernetes#v0.0.2",
+    "github>ppat/homelab-ops-kubernetes-apps//.github/renovate/custom-managers",
     "github>ppat/homelab-ops-kubernetes-apps//.github/renovate/organize-labels-deptype",
     "github>ppat/homelab-ops-kubernetes-apps//.github/renovate/organize-labels-subsystem",
     "github>ppat/homelab-ops-kubernetes-apps//.github/renovate/organize-semantic-scope",
@@ -84,6 +63,11 @@
   ],
   "prConcurrentLimit": 0,
   "prHourlyLimit": 0,
+  "printConfig": true,
   "rebaseWhen": "behind-base-branch",
+  "suppressNotifications": [
+    "prEditedNotification",
+    "prIgnoreNotification"
+  ],
   "timezone": "US/Eastern"
 }

--- a/.github/renovate/custom-managers.json
+++ b/.github/renovate/custom-managers.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/).+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-.]+?)\\s+depName=(?<depName>[a-zA-Z0-9-/]+?)(\\s+repository=(?<registryUrl>[^\\s]+?))?(\\s+versioning=(?<versioning>[^\\s]+?))?(\\s+extractVersion=(?<extractVersion>[^\\s]+?))?\\s*\\n.+[\\:\\=]\\s?\"v?(?<currentValue>[^\\s]+)\""
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^.github/workflows/.+\\.yaml$/"
+      ],
+      "matchStrings": [
+        "# renovate-kind-image: datasource=(?<datasource>[a-z-.]+?)(\\s+repository=(?<registryUrl>[^\\s]+?))?(\\s+versioning=(?<versioning>[^\\s]+?))?\\s*\\n.+[\\:\\=]\\s?\"(?<depName>[^:]+)\\:(?<currentValue>[^\\s@]+)(@(?<currentDigest>sha256:[0-9a-f]*))?\""
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/).+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate-gh-release-asset: datasource=(?<datasource>[a-z-.]+?)\\s+depName=(?<depName>[a-zA-Z0-9-/]+?)(\\s+repository=(?<registryUrl>[^\\s]+?))?(\\s+versioning=(?<versioning>[^\\s]+?))?(\\s+extractVersion=(?<extractVersion>[^\\s]+?))?\\s*\\n.+github\\.com(\\.)?\\/(.+)\\/releases\\/download\\/v(?<currentValue>[^\\/]+)\\/"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/).+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "# renovate-gh-raw-url: datasource=(?<datasource>[a-z-.]+?)\\s+depName=(?<depName>[a-zA-Z0-9-/]+?)(\\s+repository=(?<registryUrl>[^\\s]+?))?(\\s+versioning=(?<versioning>[^\\s]+?))?(\\s+extractVersion=(?<extractVersion>[^\\s]+?))?\\s*\n.+raw\\.githubusercontent\\.com(\\.)?\\/(.+)\\/v(?<currentValue>[^\\/]+)\\/"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ]
+}

--- a/.github/renovate/disable-automerge.json
+++ b/.github/renovate/disable-automerge.json
@@ -10,9 +10,6 @@
       "matchPackageNames": [
         "docker.io/mongo",
         "ghcr.io/linuxserver/unifi-network-application"
-      ],
-      "reviewers": [
-        "ppat"
       ]
     },
     {
@@ -23,9 +20,6 @@
       "description": "disable automerge for specific file paths",
       "matchFileNames": [
         "infrastructure/bootstrap/crds/**"
-      ],
-      "reviewers": [
-        "ppat"
       ]
     }
   ]

--- a/.github/renovate/disable-updates.json
+++ b/.github/renovate/disable-updates.json
@@ -34,7 +34,7 @@
       ]
     },
     {
-      "description": "disable minio updates due to OSS unfriendly practices",
+      "description": "disable minio updates due to OSS unfriendly practices until a suitable replacement is found",
       "enabled": false,
       "matchDatasources": [
         "docker"

--- a/.github/renovate/override-breaking-changes.json
+++ b/.github/renovate/override-breaking-changes.json
@@ -36,6 +36,20 @@
       ],
       "semanticCommits": "disabled",
       "commitMessagePrefix": "feat(infra-bootstrap-crds)!:"
+    },
+    {
+      "commitBody": "BREAKING CHANGE",
+      "description": "configure breaking changes for minor version upgrades of packages that treat minor versions as major versions",
+      "matchPackageNames": [
+        "fluxcd/flux2",
+        "longhorn",
+        "longhorn/longhorn"
+      ],
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "semanticCommits": "disabled",
+      "commitMessagePrefix": "feat({{#if (equals (lookup (split packageFileDir '/') 0) 'apps')}}apps{{else}}infra{{/if}}-{{ lookup (split packageFileDir '/') 2 }})!:"
     }
   ]
 }

--- a/.github/renovate/override-release-age.json
+++ b/.github/renovate/override-release-age.json
@@ -2,12 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "packageRules": [
     {
-      "description": "delay patch updates to 7 days (from 1 day) for packages managed by flux",
-      "matchManagers": [
-        "flux"
-      ],
+      "description": "delay patch updates to 7 days (from 1 day)",
       "matchPackageNames": [
-        "longhorn"
+        "longhorn",
+        "longhorn/longhorn"
       ],
       "matchUpdateTypes": [
         "patch"
@@ -15,10 +13,7 @@
       "minimumReleaseAge": "7 days"
     },
     {
-      "description": "delay patch updates to 7 days (from 1 day) for packages managed by kubernetes",
-      "matchManagers": [
-        "kubernetes"
-      ],
+      "description": "delay patch updates to 30 days (from 1 day)",
       "matchPackageNames": [
         "docker.io/mongo",
         "ghcr.io/linuxserver/unifi-network-application"
@@ -27,30 +22,16 @@
         "digest",
         "patch"
       ],
-      "minimumReleaseAge": "7 days"
-    },
-    {
-      "description": "delay minor updates to 30 days (from 7 days) for packages managed by flux",
-      "matchManagers": [
-        "flux"
-      ],
-      "matchPackageNames": [
-        "coder",
-        "longhorn"
-      ],
-      "matchUpdateTypes": [
-        "minor"
-      ],
       "minimumReleaseAge": "30 days"
     },
     {
-      "description": "delay minor updates to 30 days (from 7 days) for packages managed by kubernetes",
-      "matchManagers": [
-        "kubernetes"
-      ],
+      "description": "delay minor updates to 30 days (from 7 days)",
       "matchPackageNames": [
+        "coder",
         "docker.io/mongo",
-        "ghcr.io/linuxserver/unifi-network-application"
+        "ghcr.io/linuxserver/unifi-network-application",
+        "longhorn",
+        "longhorn/longhorn"
       ],
       "matchUpdateTypes": [
         "minor"

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -8,6 +8,8 @@ on:
   pull_request:
     paths:
     - '.github/workflows/renovate.yaml'
+    - '.github/renovate.json'
+    - '.github/renovate/*.json'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
- favor explict configuration over upstream presets when upstream presets only change 1 field
- expand config:best-practices preset and only include presets from that that's applicable
- mark as a breaking change for packages that treat minor versions as containing backwards incompatible changes
- move custom regex managers into its own file