### PR TITLE
fix(renovate): misc fixes to renovate rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,7 +21,6 @@
     "helpers:pinGitHubActionDigests",
     "mergeConfidence:age-confidence-badges",
     "mergeConfidence:all-badges",
-    "security:openssf-scorecard",
     "workarounds:bitnamiDockerImageVersioning",
     "workarounds:k3sKubernetesVersioning",
     "github>ppat/renovate-presets#v0.0.2",
@@ -44,6 +43,7 @@
     "managerFilePatterns": [
       "/apps/.+\\.yaml$/",
       "/ci/.+\\.yaml$/",
+      "/components/.+\\.yaml$/",
       "/infrastructure/.+\\.yaml$/"
     ]
   },
@@ -52,6 +52,7 @@
     "managerFilePatterns": [
       "/apps/.+\\.yaml$/",
       "/ci/.+\\.yaml$/",
+      "/components/.+\\.yaml$/",
       "/infrastructure/.+\\.yaml$/"
     ],
     "ignorePaths": [

--- a/.github/renovate/disable-updates.json
+++ b/.github/renovate/disable-updates.json
@@ -58,6 +58,16 @@
       "matchPackageNames": [
         "pihole/pihole"
       ]
+    },
+    {
+      "description": "disable pin digest on flux manager (as it tries to suffix digest to oci repository resource tags which flux rejects)",
+      "enabled": false,
+      "matchManagers": [
+        "flux"
+      ],
+      "matchUpdateTypes": [
+        "pinDigest"
+      ]
     }
   ]
 }


### PR DESCRIPTION
- do not pin digest on updates by flux manager (as it breaks oci repository resources w/ updates not accepted by flux)
- add components paths to be updated by kubernetes and flux managers
- drop security:openssf-scorecard preset